### PR TITLE
mrc-6174 make generator generic

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,7 +1,6 @@
-export interface DiscreteSystemGenerator {
-    /* eslint-disable  @typescript-eslint/no-explicit-any */
-    initial: (time: number, shared: any, internal: any, stateNext: number[]) =>
-        void,
-    update: (time: number, dt: number, state: number[], shared: any,
-             internal: any, stateNext: number[]) => void,
-};
+export interface DiscreteSystemGenerator<TShared, TInternal> {
+    initial: (time: number, shared: TShared, internal: TInternal,
+              stateNext: number[]) => void,
+    update: (time: number, dt: number, state: number[], shared: TShared,
+             internal: TInternal, stateNext: number[]) => void
+}

--- a/tests/discrete.test.ts
+++ b/tests/discrete.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest"
 
-import { DiscreteSIR } from "./examples/sir.ts";
+import {DiscreteSIR} from "./examples/sir.ts";
 
 test("can do anything with our interface", () => {
     const sir = new DiscreteSIR();

--- a/tests/discrete.test.ts
+++ b/tests/discrete.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest"
 
-import {DiscreteSIR} from "./examples/sir.ts";
+import { DiscreteSIR } from "./examples/sir.ts";
 
 test("can do anything with our interface", () => {
     const sir = new DiscreteSIR();

--- a/tests/examples/sir.ts
+++ b/tests/examples/sir.ts
@@ -1,13 +1,13 @@
 import { DiscreteSystemGenerator } from "../../src/generator.ts";
 
-export interface Shared { // we might make this private later
+interface Shared {
     N: number;
     I0: number;
     beta: number;
     gamma: number;
 }
 
-export class DiscreteSIR implements DiscreteSystemGenerator {
+export class DiscreteSIR implements DiscreteSystemGenerator<Shared, null> {
     initial(time: number, shared: Shared, internal: null, stateNext: number[]) {
         stateNext[0] = shared.N - shared.I0;
         stateNext[1] = shared.I0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,5 @@
         "noFallthroughCasesInSwitch": true,
         "noUncheckedSideEffectImports": true
     },
-    "files": ["src/index.ts"],
-    "include": ["src"]
+    "include": ["src", "tests"]
 }


### PR DESCRIPTION
I think this is the way to make the generator interface generic and make those types concrete in the class. 

Also, I don't think we need to export the shared type, so long as we use it properly. If we include tests in the typescript build, the build will fail when it tries to call initial or update in the discrete test, if you pass in a `shared` object which doesn't match the private interface.