### PR TITLE
mrc-6244 reorder

### DIFF
--- a/src/SystemState.ts
+++ b/src/SystemState.ts
@@ -119,15 +119,18 @@ export class SystemState {
     public reorder(reordering: ndarray.NdArray) {
         const shape = reordering.shape;
         if (shape.length !== 2 || shape[0] !== this._nGroups || shape[1] !== this._nParticles) {
-            throw new DustParameterError("Unexpected reordering shape. " +
-                `Expected [${this._nGroups}, ${this._nParticles}] but got ${JSON.stringify(shape)}.`);
+            throw new DustParameterError(
+                "Unexpected reordering shape. " +
+                    `Expected [${this._nGroups},${this._nParticles}] but got ${JSON.stringify(shape)}.`
+            );
         }
         // Check that each reordering contains expected values
         for (let iGroup = 0; iGroup < this._nGroups; iGroup++) {
             const reorder = particleStateToArray(reordering.pick(iGroup, null));
-            const sortedReorder= reorder.toSorted();
-            if (sortedReorder.some((value: number, index:number) => value !== index)) {
-                throw new DustParameterError("Unexpected reorder values.");
+            const sortedReorder = reorder.toSorted();
+            // Each reordering should contain every index value once so, when sorted, each value should equal its index
+            if (sortedReorder.some((value: number, index: number) => value !== index)) {
+                throw new DustParameterError(`Unexpected reorder values: ${JSON.stringify(reorder)}`);
             }
         }
 

--- a/src/SystemState.ts
+++ b/src/SystemState.ts
@@ -30,7 +30,7 @@ export interface ParticleState {
  * {@link SystemState.nStateElements | nStateElements} numeric values.
  */
 export class SystemState {
-    private readonly _state: ndarray.NdArray;
+    private _state: ndarray.NdArray;
     private readonly _nGroups: number;
     private readonly _nParticles: number;
     private readonly _nStateElements: number;
@@ -45,9 +45,13 @@ export class SystemState {
         this._nGroups = nGroups;
         this._nParticles = nParticles;
         this._nStateElements = nStateElements;
+        this._state = this.newState();
+    }
+
+    private newState() {
         // arrange the ndArray with dimensions: group, particle, stateElement
-        const len = nGroups * nParticles * nStateElements;
-        this._state = ndarray(new Array<number>(len).fill(0), [nGroups, nParticles, nStateElements]);
+        const len = this._nGroups * this._nParticles * this._nStateElements;
+        return ndarray(new Array<number>(len).fill(0), [this._nGroups, this._nParticles, this._nStateElements]);
     }
 
     /**
@@ -100,5 +104,31 @@ export class SystemState {
     private checkIndexes(iGroup: number, iParticle: number) {
         checkIntegerInRange("Group index", iGroup, 0, this._nGroups - 1);
         checkIntegerInRange("Particle index", iParticle, 0, this._nParticles - 1);
+    }
+
+    /**
+     * Apply a reordering to the particles in every group according to a reordering parameter which defines
+     * a new order for each group.
+     * @param reordering {@link https://github.com/scijs/ndarray | NdArray } whose first dimension defines group index
+     * and whose second dimension defines a new order of particles for each group. For example, if this state has three
+     * particles per group, a reordering of `[2, 0, 1]` for any group would imply that its current third particle should
+     * be reordered to the first position, its current first particle to the second position, and its current second
+     * particle to the third position.
+     */
+    public reorder(reordering: ndarray.NdArray) {
+        // TODO: expect reordering shape to be ngroups * nparticles
+        // TODO: expect each reordering to contain all and only expected values
+        const reordered = this.newState();
+        for (let iGroup = 0; iGroup < this._nGroups; iGroup++) {
+            for (let newParticleIndex = 0; newParticleIndex < this._nParticles; newParticleIndex++) {
+                const oldParticleIndex = reordering.get(iGroup, newParticleIndex);
+                const particleValues = this.getParticle(iGroup, oldParticleIndex);
+                for (let iStateElement = 0; iStateElement < this._nStateElements; iStateElement++) {
+                    reordered.set(iGroup, newParticleIndex, iStateElement, particleValues.get(iStateElement));
+                }
+            }
+        }
+
+        this._state = reordered;
     }
 }

--- a/src/SystemState.ts
+++ b/src/SystemState.ts
@@ -139,6 +139,11 @@ export class SystemState {
             }
         }
 
+        this.reorderNoCheck(reordering);
+    }
+
+    // We'll use this eventually when we want to generate our own indexes internal to the package
+    private reorderNoCheck(reordering: ndarray.NdArray) {
         for (let iGroup = 0; iGroup < this._nGroups; iGroup++) {
             for (let newParticleIndex = 0; newParticleIndex < this._nParticles; newParticleIndex++) {
                 const oldParticleIndex = reordering.get(iGroup, newParticleIndex);

--- a/src/SystemState.ts
+++ b/src/SystemState.ts
@@ -32,6 +32,7 @@ export interface ParticleState {
  */
 export class SystemState {
     private _state: ndarray.NdArray;
+    private _stateNext: ndarray.NdArray; // a working area for building next state value before swapping into _state
     private readonly _nGroups: number;
     private readonly _nParticles: number;
     private readonly _nStateElements: number;
@@ -47,6 +48,7 @@ export class SystemState {
         this._nParticles = nParticles;
         this._nStateElements = nStateElements;
         this._state = this.newState();
+        this._stateNext = this.newState();
     }
 
     private newState() {
@@ -137,17 +139,16 @@ export class SystemState {
             }
         }
 
-        const reordered = this.newState();
         for (let iGroup = 0; iGroup < this._nGroups; iGroup++) {
             for (let newParticleIndex = 0; newParticleIndex < this._nParticles; newParticleIndex++) {
                 const oldParticleIndex = reordering.get(iGroup, newParticleIndex);
                 const particleValues = this.getParticle(iGroup, oldParticleIndex);
                 for (let iStateElement = 0; iStateElement < this._nStateElements; iStateElement++) {
-                    reordered.set(iGroup, newParticleIndex, iStateElement, particleValues.get(iStateElement));
+                    this._stateNext.set(iGroup, newParticleIndex, iStateElement, particleValues.get(iStateElement));
                 }
             }
         }
 
-        this._state = reordered;
+        [this._state, this._stateNext] = [this._stateNext, this._state]; // swap
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import ndarray from "ndarray";
 import { ParticleState } from "./SystemState.ts";
+import { DustParameterError } from "./errors.ts";
 
 // Product of all values in a number array
 export const prod = (array: number[]) => array.reduce((prev, current) => prev * current, 1);
@@ -22,10 +23,17 @@ export const checkIntegerInRange = (name: string, value: number, min: number, ma
 
 // Convert an array of arrays into an NdArray
 export const ndArrayFrom = (source: number[][]): ndarray.NdArray => {
-    // TODO: check all items in source have the same length
+    if (source.length === 0) {
+        throw new DustParameterError("Cannot convert from empty source")
+    }
+    const expectedLength = source[0].length;
+    if (source.some((arr) => arr.length !== expectedLength)) {
+        throw new DustParameterError("Source arrays must all be the same length");
+    }
+
     const values = source.reduce((acc, current) => {
         acc.push(...current);
         return acc;
     }, [] as number[]);
-    return ndarray(values, [source.length, source[0].length]);
+    return ndarray(values, [source.length, expectedLength]);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import ndarray from "ndarray";
 import { ParticleState } from "./SystemState.ts";
 
 // Product of all values in a number array
@@ -17,4 +18,14 @@ export const checkIntegerInRange = (name: string, value: number, min: number, ma
         const rangeMsg = max === undefined ? `greater than or equal to ${min}` : `between ${min} and ${max}`;
         throw RangeError(`${name} should be an integer ${rangeMsg}, but is ${value}.`);
     }
+};
+
+// Convert an array of arrays into an NdArray
+export const ndArrayFrom = (source: number[][]): ndarray.NdArray => {
+    // TODO: check all items in source have the same length
+    const values = source.reduce((acc, current) => {
+        acc.push(...current);
+        return acc;
+    }, [] as number[]);
+    return ndarray(values, [source.length, source[0].length]);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,7 @@ export const checkIntegerInRange = (name: string, value: number, min: number, ma
 // Convert an array of arrays into an NdArray
 export const ndArrayFrom = (source: number[][]): ndarray.NdArray => {
     if (source.length === 0) {
-        throw new DustParameterError("Cannot convert from empty source")
+        throw new DustParameterError("Cannot convert from empty source");
     }
     const expectedLength = source[0].length;
     if (source.some((arr) => arr.length !== expectedLength)) {

--- a/tests/SystemState.test.ts
+++ b/tests/SystemState.test.ts
@@ -63,7 +63,7 @@ describe("SystemState", () => {
         expect(() => sut.setParticle(0, 0, [0, 1])).toThrowError("Particle state array must be of length 4.");
     });
 
-    test("can reorder particles", () => {
+    const createSystemStateForReorder = () => {
         const sut = new SystemState(2, 3, 2);
 
         // Initial State
@@ -75,7 +75,11 @@ describe("SystemState", () => {
         sut.setParticle(1, 0, [10, 20]);
         sut.setParticle(1, 1, [30, 40]);
         sut.setParticle(1, 2, [50, 60]);
+        return sut;
+    };
 
+    test("can reorder particles", () => {
+        const sut = createSystemStateForReorder();
         const reordering = ndArrayFrom([
             [1, 2, 0],
             [2, 0, 1]
@@ -91,6 +95,22 @@ describe("SystemState", () => {
         expect(particleStateToArray(sut.getParticle(1, 2))).toStrictEqual([30, 40]);
     });
 
+    test("can reorder particles with filter and repetition", () => {
+        const sut = createSystemStateForReorder();
+        const reordering = ndArrayFrom([
+            [1, 2, 0],
+            [2, 0, 2]
+        ]);
+        sut.reorder(reordering);
+        expect(particleStateToArray(sut.getParticle(0, 0))).toStrictEqual([3, 4]);
+        expect(particleStateToArray(sut.getParticle(0, 1))).toStrictEqual([5, 6]);
+        expect(particleStateToArray(sut.getParticle(0, 2))).toStrictEqual([1, 2]);
+
+        expect(particleStateToArray(sut.getParticle(1, 0))).toStrictEqual([50, 60]);
+        expect(particleStateToArray(sut.getParticle(1, 1))).toStrictEqual([10, 20]);
+        expect(particleStateToArray(sut.getParticle(1, 2))).toStrictEqual([50, 60]);
+    });
+
     test("throws error when attempt to reorder with unexpected reordering shape", () => {
         const sut = new SystemState(2, 3, 2);
         const reordering = ndarray(new Int32Array(4), [2, 2]);
@@ -99,12 +119,25 @@ describe("SystemState", () => {
         );
     });
 
-    test("throws error when attempt to reorder with unexpected reordering content", () => {
-        const sut = new SystemState(2, 3, 2);
+    test("throws error when attempt to reorder with negative index", () => {
+        const sut = createSystemStateForReorder();
         const reordering = ndArrayFrom([
-            [1, 2, 0],
+            [-1, 2, 0],
             [2, 0, 2]
         ]);
-        expect(() => sut.reorder(reordering)).toThrowError("Unexpected reorder values: [2,0,2]");
+        expect(() => sut.reorder(reordering)).toThrowError(
+            "Reordering index should be an integer between 0 and 2, but is -1."
+        );
+    });
+
+    test("throws error when attempt to reorder with index greater than max", () => {
+        const sut = createSystemStateForReorder();
+        const reordering = ndArrayFrom([
+            [1, 2, 0],
+            [20, 0, 2]
+        ]);
+        expect(() => sut.reorder(reordering)).toThrowError(
+            "Reordering index should be an integer between 0 and 2, but is 20."
+        );
     });
 });

--- a/tests/SystemState.test.ts
+++ b/tests/SystemState.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { SystemState } from "../src/SystemState.ts";
-import { particleStateToArray } from "../src/utils.ts";
+import { ndArrayFrom, particleStateToArray } from "../src/utils.ts";
+import ndarray from "ndarray";
 
 describe("SystemState", () => {
     const createSystemState = () => new SystemState(2, 3, 4);
@@ -60,5 +61,50 @@ describe("SystemState", () => {
     test("throws error when attempt set with array of incorrect length", () => {
         const sut = createSystemState();
         expect(() => sut.setParticle(0, 0, [0, 1])).toThrowError("Particle state array must be of length 4.");
+    });
+
+    test("can reorder particles", () => {
+        const sut = new SystemState(2, 3, 2);
+
+        // Initial State
+        // Group 0
+        sut.setParticle(0, 0, [1, 2]);
+        sut.setParticle(0, 1, [3, 4]);
+        sut.setParticle(0, 2, [5, 6]);
+        // Group 1
+        sut.setParticle(1, 0, [10, 20]);
+        sut.setParticle(1, 1, [30, 40]);
+        sut.setParticle(1, 2, [50, 60]);
+
+        const reordering = ndArrayFrom([
+            [1, 2, 0],
+            [2, 0, 1]
+        ]);
+        sut.reorder(reordering);
+
+        expect(particleStateToArray(sut.getParticle(0, 0))).toStrictEqual([3, 4]);
+        expect(particleStateToArray(sut.getParticle(0, 1))).toStrictEqual([5, 6]);
+        expect(particleStateToArray(sut.getParticle(0, 2))).toStrictEqual([1, 2]);
+
+        expect(particleStateToArray(sut.getParticle(1, 0))).toStrictEqual([50, 60]);
+        expect(particleStateToArray(sut.getParticle(1, 1))).toStrictEqual([10, 20]);
+        expect(particleStateToArray(sut.getParticle(1, 2))).toStrictEqual([30, 40]);
+    });
+
+    test("throws error when attempt to reorder with unexpected reordering shape", () => {
+        const sut = new SystemState(2, 3, 2);
+        const reordering = ndarray(new Int32Array(4), [2, 2]);
+        expect(() => sut.reorder(reordering)).toThrowError(
+            "Unexpected reordering shape. Expected [2,3] but got [2,2]."
+        );
+    });
+
+    test("throws error when attempt to reorder with unexpected reordering content", () => {
+        const sut = new SystemState(2, 3, 2);
+        const reordering = ndArrayFrom([
+            [1, 2, 0],
+            [2, 0, 2]
+        ]);
+        expect(() => sut.reorder(reordering)).toThrowError("Unexpected reorder values: [2,0,2]");
     });
 });

--- a/tests/SystemState.test.ts
+++ b/tests/SystemState.test.ts
@@ -80,7 +80,7 @@ describe("SystemState", () => {
 
     test("can reorder particles", () => {
         const sut = createSystemStateForReorder();
-        const reordering = ndArrayFrom([
+        let reordering = ndArrayFrom([
             [1, 2, 0],
             [2, 0, 1]
         ]);
@@ -92,6 +92,20 @@ describe("SystemState", () => {
 
         expect(particleStateToArray(sut.getParticle(1, 0))).toStrictEqual([50, 60]);
         expect(particleStateToArray(sut.getParticle(1, 1))).toStrictEqual([10, 20]);
+        expect(particleStateToArray(sut.getParticle(1, 2))).toStrictEqual([30, 40]);
+
+        // Test that successive reordering work as expected
+        reordering = ndArrayFrom([
+            [2, 1, 0],
+            [1, 0, 2]
+        ]);
+        sut.reorder(reordering);
+        expect(particleStateToArray(sut.getParticle(0, 0))).toStrictEqual([1, 2]);
+        expect(particleStateToArray(sut.getParticle(0, 1))).toStrictEqual([5, 6]);
+        expect(particleStateToArray(sut.getParticle(0, 2))).toStrictEqual([3, 4]);
+
+        expect(particleStateToArray(sut.getParticle(1, 0))).toStrictEqual([10, 20]);
+        expect(particleStateToArray(sut.getParticle(1, 1))).toStrictEqual([50, 60]);
         expect(particleStateToArray(sut.getParticle(1, 2))).toStrictEqual([30, 40]);
     });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { checkIntegerInRange, particleStateToArray, prod } from "../src/utils";
+import { checkIntegerInRange, ndArrayFrom, particleStateToArray, prod } from "../src/utils";
 import ndarray from "ndarray";
 import { ParticleState } from "../src/SystemState.ts";
 
@@ -54,5 +54,41 @@ describe("checkIntegerInRange", () => {
     test("does not throw when value is greater than or equal to min, when there is no max", () => {
         checkIntegerInRange("Test", 12, 10);
         checkIntegerInRange("Test", 10, 10);
+    });
+});
+
+describe("ndArrayFrom", () => {
+    test("can convert number[][] to ndArray", () => {
+        const result = ndArrayFrom([
+            [1, 2],
+            [3, 4],
+            [5, 6]
+        ]);
+        expect(result.shape).toStrictEqual([3, 2]);
+        expect(result.get(0, 0)).toBe(1);
+        expect(result.get(0, 1)).toBe(2);
+        expect(result.get(1, 0)).toBe(3);
+        expect(result.get(1, 1)).toBe(4);
+        expect(result.get(2, 0)).toBe(5);
+        expect(result.get(2, 1)).toBe(6);
+    });
+
+    test("throws error if source length is 0", () => {
+        expect(() => ndArrayFrom([])).toThrow("Cannot convert from empty source");
+    });
+
+    test("throws error if source arrays are difference length", () => {
+        expect(() => ndArrayFrom([
+            [1, 2],
+            [3, 4, 5]
+        ])).toThrow("Source arrays must all be the same length");
+    });
+
+    test("can convert array of empty arrays", () => {
+        const result = ndArrayFrom([
+            [],
+            []
+        ]);
+        expect(result.shape).toStrictEqual([2, 0]);
     });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -77,7 +77,7 @@ describe("ndArrayFrom", () => {
         expect(() => ndArrayFrom([])).toThrow("Cannot convert from empty source");
     });
 
-    test("throws error if source arrays are difference length", () => {
+    test("throws error if source arrays are different lengths", () => {
         expect(() => ndArrayFrom([
             [1, 2],
             [3, 4, 5]

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -78,17 +78,16 @@ describe("ndArrayFrom", () => {
     });
 
     test("throws error if source arrays are different lengths", () => {
-        expect(() => ndArrayFrom([
-            [1, 2],
-            [3, 4, 5]
-        ])).toThrow("Source arrays must all be the same length");
+        expect(() =>
+            ndArrayFrom([
+                [1, 2],
+                [3, 4, 5]
+            ])
+        ).toThrow("Source arrays must all be the same length");
     });
 
     test("can convert array of empty arrays", () => {
-        const result = ndArrayFrom([
-            [],
-            []
-        ]);
+        const result = ndArrayFrom([[], []]);
         expect(result.shape).toStrictEqual([2, 0]);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "ES2020",
         "useDefineForClassFields": true,
         "module": "ESNext",
-        "lib": ["ES2020"],
+        "lib": ["ESNext", "ESNext.Array"],
         "skipLibCheck": true,
         "declaration": true,
         "outDir": "./lib",


### PR DESCRIPTION
Adds a reorder method to `SystemState` (not to the System itself - users can use the `state` property on `System` to get the state). 

`reorder` takes a single `reordering` parameter which needs to be an ndarray whose first dimension defines group index and whose second dimension defines a new order of particles for each group.

Because ndarrays are a bit awkward to set up, I almost made this parameter a `number[][]` - but I've stuck with ndarray since that's our standard for handling multidimensional arrays - but I have added a util to convert to ndarray from number[][] to make calling this method easier!

