### PR TITLE
mrc-6730 resample

### DIFF
--- a/src/resample.ts
+++ b/src/resample.ts
@@ -1,12 +1,27 @@
+/**
+ * Given an array of weights, return an array of indexes into the weights array, where the number of times a weight's
+ * index appears reflects that weight's value relative to the others. The result array will have the same length as the
+ * weights array, and each index value will appear 0 or more times.
+ *
+ * @param weights The weights array
+ * @param u A number usually drawn from the unform distribution (0-1) used to offset the values associated with the
+ *          weights - this allows some random variation in the results of the resample beyond the weight values.
+ */
 export const resample = (weights: number[], u: number) => {
-    // TODO: validate weights not empty etc
     const n = weights.length;
+    if (!n) {
+        throw RangeError("Weights cannot be empty.");
+    }
+
+    // Construct a series of increments uu, starting and u/n and separated  by 1/n, each of which has a weight
+    // assigned to it according to which weight's region in the normalised cumulative sum of weights it
+    // falls into
     const uOffset = u / n;
     const uIncrement = 1 / n;
+    let uu = uOffset;
 
     const weightsSum = weights.reduce((total, current) => total + current, 0);
     const result = [];
-    let uu = uOffset;
     let weightIdx = 0;
     let cw = weights[0] / weightsSum; // normalised cumulative weight
     while (result.length < n) {

--- a/src/resample.ts
+++ b/src/resample.ts
@@ -13,7 +13,7 @@ export const resample = (weights: number[], u: number) => {
         throw RangeError("Weights cannot be empty.");
     }
 
-    // Construct a series of increments uu, starting and u/n and separated  by 1/n, each of which has a weight
+    // Construct a series of increments uu, starting at u/n and separated  by 1/n, each of which has a weight
     // assigned to it according to which weight's region in the normalised cumulative sum of weights it
     // falls into
     const uOffset = u / n;

--- a/src/resample.ts
+++ b/src/resample.ts
@@ -1,0 +1,24 @@
+export const resample = (weights: number[], u: number) => {
+    // TODO: validate weights not empty etc
+    const n = weights.length;
+    const uOffset = u / n;
+    const uIncrement = 1 / n;
+
+    const weightsSum = weights.reduce((total, current) => total + current, 0);
+    const result = [];
+    let uu = uOffset;
+    let weightIdx = 0;
+    let cw = weights[0] / weightsSum; // normalised cumulative weight
+    while (result.length < n) {
+        // On each try, see if the next uu can go in the result for the current weight index
+        // If so, add it and increment uu
+        // If not, increment the weight index and the cw
+        if (uu <= cw) {
+            result.push(weightIdx);
+            uu += uIncrement;
+        } else {
+            weightIdx++;
+            cw += weights[weightIdx] / weightsSum;
+        }
+    }
+};

--- a/src/resample.ts
+++ b/src/resample.ts
@@ -21,4 +21,5 @@ export const resample = (weights: number[], u: number) => {
             cw += weights[weightIdx] / weightsSum;
         }
     }
+    return result;
 };

--- a/tests/resample.test.ts
+++ b/tests/resample.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "vitest";
+import { resample } from "../src/resample";
+
+// Sample sets of u, w and result from the R implementation - with the result indexes shifted back 1 to no longer be
+// 1-indexed!
+const sample1 = {
+    u: 0.06986051,
+    weights: [0.019088169, 0.538700715, 0.022724325, 0.110358560, 0.023474925, 0.001216593,
+              0.058643378, 1, 0.007363703, 0.013855975, 0.009302719, 0.022136699,
+              0.091886086, 0.084838106, 0.002934530, 0.022197226, 0.088122091, 0.288347958,
+              0.163829315, 0.001286831],
+    result: [0, 1, 1, 1, 1, 3, 7, 7, 7, 7, 7, 7, 7, 7, 11, 13, 16, 17, 17, 18]
+};
+
+const sample2 = {
+    u: 0.8947567,
+    weights: [0.199120977, 0.056060287, 0.115732635, 0.033579278, 0.001514663, 0.037144679,
+              0.016340364, 0.112734953, 0.051246824, 0.157887763, 0.133908897, 0.009185324,
+              0.041430892, 0.166888607, 1, 0.009759700, 0.026224724, 0.349677617,
+              0.242408128, 0.012312731],
+    result: [0, 2, 3, 7, 9, 10, 12, 13, 14, 14, 14, 14, 14, 14, 14, 17, 17, 17, 18, 18]
+};
+
+test("resample returns expected indexes", () => {
+    expect(resample(sample1.weights, sample1.u)).toStrictEqual(sample1.result);
+    expect(resample(sample2.weights, sample2.u)).toStrictEqual(sample2.result);
+});

--- a/tests/resample.test.ts
+++ b/tests/resample.test.ts
@@ -1,27 +1,34 @@
 import { expect, test } from "vitest";
 import { resample } from "../src/resample";
 
-// Sample sets of u, w and result from the R implementation - with the result indexes shifted back 1 to no longer be
+// Sample sets of u, w and results from the R implementation - with the result indexes shifted back 1 to no longer be
 // 1-indexed!
+// sample1 - weights are abs rcauchy values normalised to <= 1
 const sample1 = {
     u: 0.06986051,
-    weights: [0.019088169, 0.538700715, 0.022724325, 0.110358560, 0.023474925, 0.001216593,
-              0.058643378, 1, 0.007363703, 0.013855975, 0.009302719, 0.022136699,
-              0.091886086, 0.084838106, 0.002934530, 0.022197226, 0.088122091, 0.288347958,
-              0.163829315, 0.001286831],
+    weights: [
+        0.019088169, 0.538700715, 0.022724325, 0.11035856, 0.023474925, 0.001216593, 0.058643378, 1, 0.007363703,
+        0.013855975, 0.009302719, 0.022136699, 0.091886086, 0.084838106, 0.00293453, 0.022197226, 0.088122091,
+        0.288347958, 0.163829315, 0.001286831
+    ],
     result: [0, 1, 1, 1, 1, 3, 7, 7, 7, 7, 7, 7, 7, 7, 11, 13, 16, 17, 17, 18]
 };
 
+// sample2 - weights are abs rcauchy values which have not been normalised
 const sample2 = {
-    u: 0.8947567,
-    weights: [0.199120977, 0.056060287, 0.115732635, 0.033579278, 0.001514663, 0.037144679,
-              0.016340364, 0.112734953, 0.051246824, 0.157887763, 0.133908897, 0.009185324,
-              0.041430892, 0.166888607, 1, 0.009759700, 0.026224724, 0.349677617,
-              0.242408128, 0.012312731],
-    result: [0, 2, 3, 7, 9, 10, 12, 13, 14, 14, 14, 14, 14, 14, 14, 17, 17, 17, 18, 18]
+    u: 0.743724,
+    weights: [
+        0.196809, 4.5023123, 0.8761269, 1.276677, 0.2772459, 0.3513575, 34.6684442, 0.3435429, 5.5966848, 0.7134911,
+        0.6687651, 0.268905, 2.5180958, 0.5147385, 0.5930055, 7.6698852, 1.393964, 3.6808606, 2.1501077, 0.3640676
+    ],
+    result: [1, 3, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 8, 12, 15, 15, 15, 17, 18]
 };
 
 test("resample returns expected indexes", () => {
     expect(resample(sample1.weights, sample1.u)).toStrictEqual(sample1.result);
     expect(resample(sample2.weights, sample2.u)).toStrictEqual(sample2.result);
+});
+
+test("resample throws error when passed empty weights array", () => {
+    expect(() => resample([], sample1.u)).toThrow("Weights cannot be empty.");
 });


### PR DESCRIPTION
Resample algorithm which will be used in the particle filter to resample particles based on their log likelihoods.

This should produce the same results as the 
R implementation: https://github.com/mrc-ide/dust2/blob/main/tests/testthat/test-filter-details.R#L2-L7
and
C++ implementation (which, like js, has to do without R's `findInterval` method: https://github.com/mrc-ide/dust2/blob/d0a72cc01e95a5ecc80ef606fe4fd9676528918f/inst/include/dust2/filter_details.hpp#L46

The `resample` method is deterministic, although it takes a parameter `u` which would typically be randomly drawn. I've included tests with expected results taken from the R implementation. 