### PR TITLE
Mrc 6751 Add generic array slicing in Packer based on number of variables from start

### DIFF
--- a/src/Packer.ts
+++ b/src/Packer.ts
@@ -57,6 +57,7 @@ export class Packer {
     private readonly _length: number; // Total number of values
     private readonly _idx: Record<string, IndexValues>; // Maps value names to starting index and length in packed data
     private readonly _shape: PackerShape;
+    private readonly _nVariables: number;
 
     /**
      *
@@ -65,6 +66,7 @@ export class Packer {
     constructor(options: PackerOptions) {
         this._idx = {};
         this._shape = options.shape;
+        this._nVariables = options.shape.size;
         this._length = 0;
         for (const [name, value] of this._shape) {
             validateShape(name, value);
@@ -86,6 +88,13 @@ export class Packer {
      */
     public get length() {
         return this._length;
+    }
+
+    /**
+     * Returns the number of variables in the shape used to initialise this Packer.
+     */
+    public get nVariables() {
+        return this._nVariables;
     }
 
     private isScalar(name: string) {

--- a/src/Packer.ts
+++ b/src/Packer.ts
@@ -102,17 +102,11 @@ export class Packer {
     }
 
     /**
-     * Slices array based on numbers of variables while respecting the the length of each variables.
-     * @param x A number array corresponding to the shape this class was initialised with.
-     * @param nVariables Number of variables to include in the slice
+     * Calculates the length of array required to contain the first n variables from the
+     * start of the shape this Packer was initialised with.
+     * @param nVariables Number of variables
      */
-    public sliceArray(x: Array<number>, nVariables: number) {
-        if (x.length > this.length) {
-            throw Error(
-                `The given array's length ${x.length} is larger than max size of flat array ` +
-                    `this packer supports (${this.length}).`
-            );
-        }
+    public flatLengthFromStart(nVariables: number) {
         if (nVariables > this._shape.size) {
             throw Error(
                 `nVariables (${nVariables}) cannot be larger than total number of ` + `variables ${this._shape.size}.`
@@ -121,8 +115,7 @@ export class Packer {
 
         const key = Array.from(this._shape.keys())[nVariables - 1];
         const { start, length } = this._idx[key];
-        const sliceEnd = start + length;
-        return x.slice(0, sliceEnd);
+        return start + length;
     }
 
     /**

--- a/src/Packer.ts
+++ b/src/Packer.ts
@@ -110,20 +110,20 @@ export class Packer {
     public flatLengthBetweenVariables(firstVariablePosition: number, lastVariablePosition: number) {
         if (firstVariablePosition > lastVariablePosition) {
             throw Error(
-                `firstVariablePosition (${firstVariablePosition}) cannot be larger `
-                + `than lastVariablePosition (${lastVariablePosition}).`
-            )
+                `firstVariablePosition (${firstVariablePosition}) cannot be larger ` +
+                    `than lastVariablePosition (${lastVariablePosition}).`
+            );
         }
 
         if (lastVariablePosition > this._shape.size - 1) {
             throw Error(
-                `lastVariablePosition (${lastVariablePosition}) cannot `
-                + `be larger than largest index of variables ${this._shape.size - 1}.`
+                `lastVariablePosition (${lastVariablePosition}) cannot ` +
+                    `be larger than largest index of variables ${this._shape.size - 1}.`
             );
         }
 
         const keys = Array.from(this._shape.keys());
-        
+
         const firstKey = keys[firstVariablePosition];
         const { start: firstStart } = this._idx[firstKey];
 

--- a/src/Packer.ts
+++ b/src/Packer.ts
@@ -104,18 +104,33 @@ export class Packer {
     /**
      * Calculates the length of array required to contain the first n variables from the
      * start of the shape this Packer was initialised with.
-     * @param nVariables Number of variables
+     * @param firstVariablePosition Index of start variable (inclusive)
+     * @param lastVariablePosition Index of final variable (not inclusive)
      */
-    public flatLengthFromStart(nVariables: number) {
-        if (nVariables > this._shape.size) {
+    public flatLengthBetweenVariables(firstVariablePosition: number, lastVariablePosition: number) {
+        if (firstVariablePosition > lastVariablePosition) {
             throw Error(
-                `nVariables (${nVariables}) cannot be larger than total number of ` + `variables ${this._shape.size}.`
+                `firstVariablePosition (${firstVariablePosition}) cannot be larger `
+                + `than lastVariablePosition (${lastVariablePosition}).`
+            )
+        }
+
+        if (lastVariablePosition > this._shape.size - 1) {
+            throw Error(
+                `lastVariablePosition (${lastVariablePosition}) cannot `
+                + `be larger than largest index of variables ${this._shape.size - 1}.`
             );
         }
 
-        const key = Array.from(this._shape.keys())[nVariables - 1];
-        const { start, length } = this._idx[key];
-        return start + length;
+        const keys = Array.from(this._shape.keys());
+        
+        const firstKey = keys[firstVariablePosition];
+        const { start: firstStart } = this._idx[firstKey];
+
+        const lastKey = keys[lastVariablePosition];
+        const { start: lastStart } = this._idx[lastKey];
+
+        return lastStart - firstStart;
     }
 
     /**

--- a/tests/Packer.test.ts
+++ b/tests/Packer.test.ts
@@ -55,6 +55,17 @@ describe("Packer class", () => {
             expect(sut["_shape"]).toBe(mixedShape);
         });
 
+        test("can get correct nVariables", () => {
+            let sut = new Packer({ shape: scalarShape });
+            expect(sut.nVariables).toBe(3);
+
+            sut = new Packer({ shape: arrayShape });
+            expect(sut.nVariables).toBe(2);
+
+            sut = new Packer({ shape: mixedShape });
+            expect(sut.nVariables).toBe(5);
+        });
+
         test("build expected array slice for packer with both scalar and array values", () => {
             const sut = new Packer({ shape: mixedShape });
             const stateArray = Array(sut.length).fill(0);

--- a/tests/Packer.test.ts
+++ b/tests/Packer.test.ts
@@ -55,21 +55,30 @@ describe("Packer class", () => {
             expect(sut["_shape"]).toBe(mixedShape);
         });
 
-        test("build expected rhsVariableLength for packer with both scalar and array values", () => {
-            let sut = new Packer({ shape: mixedShape });
-            expect(sut.rhsVariableLength).toBe(14);
+        test("build expected array slice for packer with both scalar and array values", () => {
+            const sut = new Packer({ shape: mixedShape });
+            const stateArray = Array(sut.length).fill(0);
 
-            sut = new Packer({ shape: mixedShape, nRhsVariables: 2 });
-            expect(sut.rhsVariableLength).toBe(4);
-
-            sut = new Packer({ shape: mixedShape, nRhsVariables: 4 });
-            expect(sut.rhsVariableLength).toBe(13);
+            expect(sut.sliceArray(stateArray, 2).length).toBe(4);
+            expect(sut.sliceArray(stateArray, 4).length).toBe(13);
         });
 
-        test("throws error if nRhsVariables exceeds shape size", () => {
+        test("slice array throws error if stateArray exceeds packer length", () => {
             expect(() => {
-                new Packer({ shape: mixedShape, nRhsVariables: 6 });
-            }).toThrowError("nRhsVariables (6) cannot be larger than total number of variables 5.");
+                const sut = new Packer({ shape: mixedShape });
+                const stateArray = Array(sut.length + 1).fill(0);
+                sut.sliceArray(stateArray, 4);
+            }).toThrowError(
+                "The given array's length 15 is larger than max size of flat array this packer supports (14)"
+            );
+        });
+
+        test("slice array throws error if nVariables exceeds shape size", () => {
+            expect(() => {
+                const sut = new Packer({ shape: mixedShape });
+                const stateArray = Array(sut.length).fill(0);
+                sut.sliceArray(stateArray, 6);
+            }).toThrowError("nVariables (6) cannot be larger than total number of variables 5.");
         });
 
         test("throws error if empty shape", () => {

--- a/tests/Packer.test.ts
+++ b/tests/Packer.test.ts
@@ -57,13 +57,13 @@ describe("Packer class", () => {
 
         test("build expected rhsVariableLength for packer with both scalar and array values", () => {
             let sut = new Packer({ shape: mixedShape });
-            expect(sut["_rhsVariableLength"]).toBe(14);
+            expect(sut.rhsVariableLength).toBe(14);
 
             sut = new Packer({ shape: mixedShape, nRhsVariables: 2 });
-            expect(sut["_rhsVariableLength"]).toBe(4);
+            expect(sut.rhsVariableLength).toBe(4);
 
             sut = new Packer({ shape: mixedShape, nRhsVariables: 4 });
-            expect(sut["_rhsVariableLength"]).toBe(13);
+            expect(sut.rhsVariableLength).toBe(13);
         });
 
         test("throws error if nRhsVariables exceeds shape size", () => {

--- a/tests/Packer.test.ts
+++ b/tests/Packer.test.ts
@@ -55,6 +55,23 @@ describe("Packer class", () => {
             expect(sut["_shape"]).toBe(mixedShape);
         });
 
+        test("build expected rhsVariableLength for packer with both scalar and array values", () => {
+            let sut = new Packer({ shape: mixedShape });
+            expect(sut["_rhsVariableLength"]).toBe(14);
+
+            sut = new Packer({ shape: mixedShape, nRhsVariables: 2 });
+            expect(sut["_rhsVariableLength"]).toBe(4);
+
+            sut = new Packer({ shape: mixedShape, nRhsVariables: 4 });
+            expect(sut["_rhsVariableLength"]).toBe(13);
+        });
+
+        test("throws error if nRhsVariables exceeds shape size", () => {
+            expect(() => {
+                new Packer({ shape: mixedShape, nRhsVariables: 6 });
+            }).toThrowError("nRhsVariables (6) cannot be larger than total number of variables 5.");
+        });
+
         test("throws error if empty shape", () => {
             expect(() => {
                 new Packer({ shape: new Map([]) });

--- a/tests/Packer.test.ts
+++ b/tests/Packer.test.ts
@@ -68,27 +68,15 @@ describe("Packer class", () => {
 
         test("build expected array slice for packer with both scalar and array values", () => {
             const sut = new Packer({ shape: mixedShape });
-            const stateArray = Array(sut.length).fill(0);
 
-            expect(sut.sliceArray(stateArray, 2).length).toBe(4);
-            expect(sut.sliceArray(stateArray, 4).length).toBe(13);
-        });
-
-        test("slice array throws error if stateArray exceeds packer length", () => {
-            expect(() => {
-                const sut = new Packer({ shape: mixedShape });
-                const stateArray = Array(sut.length + 1).fill(0);
-                sut.sliceArray(stateArray, 4);
-            }).toThrowError(
-                "The given array's length 15 is larger than max size of flat array this packer supports (14)"
-            );
+            expect(sut.flatLengthFromStart(2)).toBe(4);
+            expect(sut.flatLengthFromStart(4)).toBe(13);
         });
 
         test("slice array throws error if nVariables exceeds shape size", () => {
             expect(() => {
                 const sut = new Packer({ shape: mixedShape });
-                const stateArray = Array(sut.length).fill(0);
-                sut.sliceArray(stateArray, 6);
+                sut.flatLengthFromStart(6);
             }).toThrowError("nVariables (6) cannot be larger than total number of variables 5.");
         });
 

--- a/tests/Packer.test.ts
+++ b/tests/Packer.test.ts
@@ -78,20 +78,14 @@ describe("Packer class", () => {
             expect(() => {
                 const sut = new Packer({ shape: mixedShape });
                 sut.flatLengthBetweenVariables(3, 2);
-            }).toThrowError(
-                "firstVariablePosition (3) cannot be larger than "
-                + "lastVariablePosition (2)."
-            );
+            }).toThrowError("firstVariablePosition (3) cannot be larger than " + "lastVariablePosition (2).");
         });
 
         test("slice array throws error if end variable position exceeds shape size - 1", () => {
             expect(() => {
                 const sut = new Packer({ shape: mixedShape });
                 sut.flatLengthBetweenVariables(0, 5);
-            }).toThrowError(
-                "lastVariablePosition (5) cannot be larger than largest "
-                + "index of variables 4."
-            );
+            }).toThrowError("lastVariablePosition (5) cannot be larger than largest " + "index of variables 4.");
         });
 
         test("throws error if empty shape", () => {

--- a/tests/Packer.test.ts
+++ b/tests/Packer.test.ts
@@ -69,15 +69,29 @@ describe("Packer class", () => {
         test("build expected array slice for packer with both scalar and array values", () => {
             const sut = new Packer({ shape: mixedShape });
 
-            expect(sut.flatLengthFromStart(2)).toBe(4);
-            expect(sut.flatLengthFromStart(4)).toBe(13);
+            expect(sut.flatLengthBetweenVariables(0, 2)).toBe(4);
+            expect(sut.flatLengthBetweenVariables(0, 4)).toBe(13);
+            expect(sut.flatLengthBetweenVariables(2, 4)).toBe(9);
         });
 
-        test("slice array throws error if nVariables exceeds shape size", () => {
+        test("slice array throws error if start variable position exceeds end position", () => {
             expect(() => {
                 const sut = new Packer({ shape: mixedShape });
-                sut.flatLengthFromStart(6);
-            }).toThrowError("nVariables (6) cannot be larger than total number of variables 5.");
+                sut.flatLengthBetweenVariables(3, 2);
+            }).toThrowError(
+                "firstVariablePosition (3) cannot be larger than "
+                + "lastVariablePosition (2)."
+            );
+        });
+
+        test("slice array throws error if end variable position exceeds shape size - 1", () => {
+            expect(() => {
+                const sut = new Packer({ shape: mixedShape });
+                sut.flatLengthBetweenVariables(0, 5);
+            }).toThrowError(
+                "lastVariablePosition (5) cannot be larger than largest "
+                + "index of variables 4."
+            );
         });
 
         test("throws error if empty shape", () => {


### PR DESCRIPTION
This PR adds an option to Packer class `nRhsVariables` to allow user to specify how many variables (counting from the first one) they would like to feed into the `rhs` generator function, meaning that the rest of the state will be from the `output` function

from the `nRhsVariable` we calculate the length of the rhs variables and save that as a member of the class, this will be used later to slice the state array into the correct subarray to feed into the solver (correct subarray being one that contains only the variables that are used in the rhs)