### PR TITLE
Mrc 6752 Add optimised run particle mode letting solver pick dt

### DIFF
--- a/src/System.ts
+++ b/src/System.ts
@@ -9,6 +9,7 @@ import {
     checkIntegerInRange,
     checkTimes,
     floatIsDivisibleBy,
+    isPositiveFinite,
     particleStateToArray
 } from "./utils.ts";
 import { DustParameterError } from "./errors.ts";
@@ -51,10 +52,19 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
         checkIntegerInRange("Number of particles", nParticles, 1);
 
         this._generatorCfg = generatorCfg;
-        const { generator } = generatorCfg;
+        const { generator, isContinuous } = generatorCfg;
+
+        if (!isContinuous) {
+          if (!isPositiveFinite(dt)) {
+            throw Error(`dt provided, ${dt}, must be positive and finite`);
+          }
+          this._dt = dt;
+        } else {
+          // value of 0 for _dt means we let solver pick dt and use runParticleWithSolver
+          this._dt = isPositiveFinite(dt) ? dt : 0;
+        }
 
         this._time = time;
-        this._dt = dt;
         this._nParticles = nParticles; // number of particles per parameter set
         this._nGroups = shared.length; // number of parameter sets
         this._statePacker = generator.packingState(shared[0]);
@@ -75,7 +85,7 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
      * @param generator Discrete generator (model) implementation for the System
      * @param shared Array of TShared, each representing the parameters for a group of particles
      * @param time Initial time for the system
-     * @param dt Time step to be used when updating the system
+     * @param dt Time step to be used when updating the system, will error if dt <= 0 or dt is Infinity
      * @param nParticles Number of particles per group
      * @param nRhsVariables Number of variables to feed into the rhs function of the generator. This
      * may be less than the number of variables of the system if some variables are calculated from
@@ -103,7 +113,9 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
      * @param generator Continuous ODE generator (model) implementation for the System
      * @param dt Time step to be used when updating the system. If the generator does not
      * have an update method or a zeroEvery method then this parameter will be ignored in
-     * favour of a more optimised dt that the solver picks
+     * favour of a more optimised dt that the solver picks. Additionally, if dt <= 0 or dt
+     * is Infinity the solver will ignore any update or zeroEvery method on the generator
+     * and let the solver run the continuous system.
      * @copyDoc System.createDiscrete
      */
     static createODE<TShared, TInternal, TData = null>(
@@ -315,7 +327,7 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
 
     private runParticleWithSolver(particleState: ParticleState, endTime: number, solver: dopri.Dopri): number[] {
         const state = particleStateToArray(particleState);
-        solver.initialise(this._time, state.slice(0, this._statePacker.rhsVariableLength));
+        solver.initialise(this._time, state.slice(0, this._rhsVariablesLength));
         const solution = solver.run(endTime);
         return solution([endTime])[0];
     }
@@ -330,8 +342,9 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
         endTime: number
     ): number[] {
         const { isContinuous, generator } = this._generatorCfg;
-        if (isContinuous && solver && !generator.update && !generator.getZeroEvery) {
-            // if continuous and no time specific updates like zeroEvery and update methods
+        const noUpdateOrZeroEvery = isContinuous && solver && !generator.update && !generator.getZeroEvery;
+        const invalidDt = isContinuous && solver && this._dt === 0;
+        if (noUpdateOrZeroEvery || invalidDt) {
             return this.runParticleWithSolver(particleState, endTime, solver);
         } else {
             return this.runParticleWithDt(shared, internal, zeroEvery, particleState, nSteps, solver);

--- a/src/System.ts
+++ b/src/System.ts
@@ -55,13 +55,13 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
         const { generator, isContinuous } = generatorCfg;
 
         if (!isContinuous) {
-          if (!isPositiveFinite(dt)) {
-            throw Error(`dt provided, ${dt}, must be positive and finite`);
-          }
-          this._dt = dt;
+            if (!isPositiveFinite(dt)) {
+                throw Error(`dt provided, ${dt}, must be positive and finite`);
+            }
+            this._dt = dt;
         } else {
-          // value of 0 for _dt means we let solver pick dt and use runParticleWithSolver
-          this._dt = isPositiveFinite(dt) ? dt : 0;
+            // value of 0 for _dt means we let solver pick dt and use runParticleWithSolver
+            this._dt = isPositiveFinite(dt) ? dt : 0;
         }
 
         this._time = time;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export type { DiscreteGenerator } from "./interfaces/generators/DiscreteGenerato
 export type {
     Solution,
     FullSolution,
+    ContinuousGeneratorBase,
     ContinuousGeneratorODE,
     ContinuousGeneratorDDE
 } from "./interfaces/generators/ContinuousGenerator.ts";

--- a/src/interfaces/generators/BaseGenerator.ts
+++ b/src/interfaces/generators/BaseGenerator.ts
@@ -27,27 +27,6 @@ export interface BaseGenerator<TShared, TInternal, TData> {
     initial(time: number, shared: TShared, internal: TInternal, stateNext: number[], random: Random): void;
 
     /**
-     * Updates the state of a particle from its previous state.
-     *
-     * @param time The new time to which the particle state should be updated.
-     * @param dt The time step from the current time to the new time
-     * @param state The current state of the particle
-     * @param shared The shared parameter values used by the particle's group
-     * @param internal The internal state used by the particle's group
-     * @param stateNext The array of values which should be updated by the generator with new particle state values
-     * @param random A random number generator which may be used by the generator to update values
-     */
-    update(
-        time: number,
-        dt: number,
-        state: number[],
-        shared: TShared,
-        internal: TInternal,
-        stateNext: number[],
-        random: Random
-    ): void;
-
-    /**
      * Generates initial internal state for a given shared state
      * @param shared The shared state to generate initial internal state for
      */

--- a/src/interfaces/generators/ContinuousGenerator.ts
+++ b/src/interfaces/generators/ContinuousGenerator.ts
@@ -1,3 +1,4 @@
+import { Random } from "@reside-ic/random";
 import { BaseGenerator } from "./BaseGenerator.ts";
 
 /**
@@ -16,12 +17,34 @@ export type Solution = (t: number) => number[];
 export type FullSolution = (t: number[]) => number[][];
 
 /**
+ * Base interface for {@link ContinuousGeneratorODE} and {@link ContinuousGeneratorDDE} that defines update
+ * method as optional
+ *
+ * @copyDoc BaseGenerator
+ */
+export interface ContinuousGeneratorBase<TShared, TInternal, TData> extends BaseGenerator<TShared, TInternal, TData> {
+    /**
+     * @copyDoc DiscreteGenerator.update
+     */
+    update?(
+        time: number,
+        dt: number,
+        state: number[],
+        shared: TShared,
+        internal: TInternal,
+        stateNext: number[],
+        random: Random
+    ): void;
+}
+
+/**
  * This interface defines the functionality of a continuous time model without delays, which can be
  * used by {@link System} to initialise and update particles.
  *
  * @copyDoc BaseGenerator
  */
-export interface ContinuousGeneratorODE<TShared, TInternal, TData> extends BaseGenerator<TShared, TInternal, TData> {
+export interface ContinuousGeneratorODE<TShared, TInternal, TData>
+    extends ContinuousGeneratorBase<TShared, TInternal, TData> {
     /**
      * Compute the derivatives
      *
@@ -51,7 +74,8 @@ export interface ContinuousGeneratorODE<TShared, TInternal, TData> extends BaseG
  *
  * @copyDoc BaseGenerator
  */
-export interface ContinuousGeneratorDDE<TShared, TInternal, TData> extends BaseGenerator<TShared, TInternal, TData> {
+export interface ContinuousGeneratorDDE<TShared, TInternal, TData>
+    extends ContinuousGeneratorBase<TShared, TInternal, TData> {
     /**
      * @copyDoc ContinuousGeneratorODE.rhs
      *

--- a/src/interfaces/generators/DiscreteGenerator.ts
+++ b/src/interfaces/generators/DiscreteGenerator.ts
@@ -1,3 +1,4 @@
+import { Random } from "@reside-ic/random";
 import { BaseGenerator } from "./BaseGenerator.ts";
 
 /**
@@ -6,4 +7,25 @@ import { BaseGenerator } from "./BaseGenerator.ts";
  *
  * @copyDoc BaseGenerator
  */
-export interface DiscreteGenerator<TShared, TInternal, TData> extends BaseGenerator<TShared, TInternal, TData> {}
+export interface DiscreteGenerator<TShared, TInternal, TData> extends BaseGenerator<TShared, TInternal, TData> {
+    /**
+     * Updates the state of a particle from its previous state.
+     *
+     * @param time The new time to which the particle state should be updated.
+     * @param dt The time step from the current time to the new time
+     * @param state The current state of the particle
+     * @param shared The shared parameter values used by the particle's group
+     * @param internal The internal state used by the particle's group
+     * @param stateNext The array of values which should be updated by the generator with new particle state values
+     * @param random A random number generator which may be used by the generator to update values
+     */
+    update(
+        time: number,
+        dt: number,
+        state: number[],
+        shared: TShared,
+        internal: TInternal,
+        stateNext: number[],
+        random: Random
+    ): void;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,3 +104,5 @@ export const floatIsDivisibleBy = (a: number, b: number, tolerance = 1e-12) => {
     const isAlmostB = b - (a % b) < tolerance;
     return isAlmostZero || isAlmostB;
 };
+
+export const isPositiveFinite = (x: number) => x > 0 && Number.isFinite(x);

--- a/tests/ContinuousSystem.test.ts
+++ b/tests/ContinuousSystem.test.ts
@@ -3,14 +3,14 @@ import { System } from "../src/System.ts";
 import { constantGrad, ConstantGradShared } from "./examples/constantGrad.ts";
 import { constantGradNoUpdate, ConstantGradNoUpdateShared } from "./examples/constantGradNoUpdate.ts";
 
-const createSystem = (shared: ConstantGradShared) =>
+const createSystem = (shared: ConstantGradShared, dt = 0.001) =>
     System.createODE<ConstantGradShared, null>(
         constantGrad,
         [shared],
         5, // time
-        0.001, // dt
+        dt, // dt
         1, // nParticles
-        undefined
+        1 // nRhsVariables
     );
 
 const createSystemNoUpdate = (shared: ConstantGradNoUpdateShared) =>
@@ -23,6 +23,30 @@ const createSystemNoUpdate = (shared: ConstantGradNoUpdateShared) =>
         1 // nRhsVariables
     );
 
+type ExpectedResult = {
+    y: number[],
+    yAddOne: number[],
+}
+
+const expectResult = (sys: System<any, any, any>, expectedResult: ExpectedResult) => {
+    sys.setStateInitial();
+    const result = sys.simulate([6, 7, 8, 9, 10]).resultValues().data;
+
+    // y
+    expect(result[0]).toBeCloseTo(expectedResult.y[0]);
+    expect(result[1]).toBeCloseTo(expectedResult.y[1]);
+    expect(result[2]).toBeCloseTo(expectedResult.y[2]);
+    expect(result[3]).toBeCloseTo(expectedResult.y[3]);
+    expect(result[4]).toBeCloseTo(expectedResult.y[4]);
+
+    // yAddOne
+    expect(result[5]).toBeCloseTo(expectedResult.yAddOne[0]);
+    expect(result[6]).toBeCloseTo(expectedResult.yAddOne[1]);
+    expect(result[7]).toBeCloseTo(expectedResult.yAddOne[2]);
+    expect(result[8]).toBeCloseTo(expectedResult.yAddOne[3]);
+    expect(result[9]).toBeCloseTo(expectedResult.yAddOne[4]);
+};
+
 describe("ContinuousSystem", () => {
     afterEach(() => {
         vi.restoreAllMocks();
@@ -30,41 +54,37 @@ describe("ContinuousSystem", () => {
 
     test("Can initialise and run to time using constantGrad generator", () => {
         const sys = createSystem({ y: 1, yAddOne: 2 });
-        sys.setStateInitial();
-        const result = sys.simulate([6, 7, 8, 9, 10]).resultValues().data;
+        expectResult(sys, {
+            y: [2, 3, 4, 101, 102],
+            yAddOne: [3, 4, 5, 102, 103],
+        });
+    });
 
-        // y
-        expect(result[0]).toBeCloseTo(2);
-        expect(result[1]).toBeCloseTo(3);
-        expect(result[2]).toBeCloseTo(4);
-        expect(result[3]).toBeCloseTo(101);
-        expect(result[4]).toBeCloseTo(102);
+    test("providing dt <= 0 or Infinity ignores update", () => {
+        let sys = createSystem({ y: 1, yAddOne: 2 }, -1);
+        expectResult(sys, {
+            y: [2, 3, 4, 5, 6],
+            yAddOne: [3, 4, 5, 6, 7],
+        });
 
-        // yAddOne
-        expect(result[5]).toBeCloseTo(3);
-        expect(result[6]).toBeCloseTo(4);
-        expect(result[7]).toBeCloseTo(5);
-        expect(result[8]).toBeCloseTo(102);
-        expect(result[9]).toBeCloseTo(103);
+        sys = createSystem({ y: 1, yAddOne: 2 }, 0);
+        expectResult(sys, {
+            y: [2, 3, 4, 5, 6],
+            yAddOne: [3, 4, 5, 6, 7],
+        });
+
+        sys = createSystem({ y: 1, yAddOne: 2 }, Infinity);
+        expectResult(sys, {
+            y: [2, 3, 4, 5, 6],
+            yAddOne: [3, 4, 5, 6, 7],
+        });
     });
 
     test("Can initialise and run to time using constantGradNoUpdate generator", () => {
         const sys = createSystemNoUpdate({ y: 1, yAddOne: 2 });
-        sys.setStateInitial();
-        const result = sys.simulate([6, 7, 8, 9, 10]).resultValues().data;
-
-        // y
-        expect(result[0]).toBeCloseTo(2);
-        expect(result[1]).toBeCloseTo(3);
-        expect(result[2]).toBeCloseTo(4);
-        expect(result[3]).toBeCloseTo(5);
-        expect(result[4]).toBeCloseTo(6);
-
-        // yAddOne
-        expect(result[5]).toBeCloseTo(3);
-        expect(result[6]).toBeCloseTo(4);
-        expect(result[7]).toBeCloseTo(5);
-        expect(result[8]).toBeCloseTo(6);
-        expect(result[9]).toBeCloseTo(7);
+        expectResult(sys, {
+            y: [2, 3, 4, 5, 6],
+            yAddOne: [3, 4, 5, 6, 7],
+        });
     });
 });

--- a/tests/ContinuousSystem.test.ts
+++ b/tests/ContinuousSystem.test.ts
@@ -24,9 +24,9 @@ const createSystemNoUpdate = (shared: ConstantGradNoUpdateShared) =>
     );
 
 type ExpectedResult = {
-    y: number[],
-    yAddOne: number[],
-}
+    y: number[];
+    yAddOne: number[];
+};
 
 const expectResult = (sys: System<any, any, any>, expectedResult: ExpectedResult) => {
     sys.setStateInitial();
@@ -56,7 +56,7 @@ describe("ContinuousSystem", () => {
         const sys = createSystem({ y: 1, yAddOne: 2 });
         expectResult(sys, {
             y: [2, 3, 4, 101, 102],
-            yAddOne: [3, 4, 5, 102, 103],
+            yAddOne: [3, 4, 5, 102, 103]
         });
     });
 
@@ -64,19 +64,19 @@ describe("ContinuousSystem", () => {
         let sys = createSystem({ y: 1, yAddOne: 2 }, -1);
         expectResult(sys, {
             y: [2, 3, 4, 5, 6],
-            yAddOne: [3, 4, 5, 6, 7],
+            yAddOne: [3, 4, 5, 6, 7]
         });
 
         sys = createSystem({ y: 1, yAddOne: 2 }, 0);
         expectResult(sys, {
             y: [2, 3, 4, 5, 6],
-            yAddOne: [3, 4, 5, 6, 7],
+            yAddOne: [3, 4, 5, 6, 7]
         });
 
         sys = createSystem({ y: 1, yAddOne: 2 }, Infinity);
         expectResult(sys, {
             y: [2, 3, 4, 5, 6],
-            yAddOne: [3, 4, 5, 6, 7],
+            yAddOne: [3, 4, 5, 6, 7]
         });
     });
 
@@ -84,7 +84,7 @@ describe("ContinuousSystem", () => {
         const sys = createSystemNoUpdate({ y: 1, yAddOne: 2 });
         expectResult(sys, {
             y: [2, 3, 4, 5, 6],
-            yAddOne: [3, 4, 5, 6, 7],
+            yAddOne: [3, 4, 5, 6, 7]
         });
     });
 });

--- a/tests/ContinuousSystem.test.ts
+++ b/tests/ContinuousSystem.test.ts
@@ -1,12 +1,21 @@
 import { describe, test, expect, vi, afterEach } from "vitest";
 import { System } from "../src/System.ts";
 import { constantGrad, ConstantGradShared } from "./examples/constantGrad.ts";
-
-const generator = constantGrad;
+import { constantGradNoUpdate, ConstantGradNoUpdateShared } from "./examples/constantGradNoUpdate.ts";
 
 const createSystem = (shared: ConstantGradShared) =>
     System.createODE<ConstantGradShared, null>(
-        generator,
+        constantGrad,
+        [shared],
+        5, // time
+        0.001, // dt
+        1, // nParticles
+        undefined
+    );
+
+const createSystemNoUpdate = (shared: ConstantGradNoUpdateShared) =>
+    System.createODE<ConstantGradNoUpdateShared, null>(
+        constantGradNoUpdate,
         [shared],
         5, // time
         0.001, // dt
@@ -37,5 +46,25 @@ describe("ContinuousSystem", () => {
         expect(result[7]).toBeCloseTo(5);
         expect(result[8]).toBeCloseTo(102);
         expect(result[9]).toBeCloseTo(103);
+    });
+
+    test("Can initialise and run to time using constantGradNoUpdate generator", () => {
+        const sys = createSystemNoUpdate({ y: 1, yAddOne: 2 });
+        sys.setStateInitial();
+        const result = sys.simulate([6, 7, 8, 9, 10]).resultValues().data;
+
+        // y
+        expect(result[0]).toBeCloseTo(2);
+        expect(result[1]).toBeCloseTo(3);
+        expect(result[2]).toBeCloseTo(4);
+        expect(result[3]).toBeCloseTo(5);
+        expect(result[4]).toBeCloseTo(6);
+
+        // yAddOne
+        expect(result[5]).toBeCloseTo(3);
+        expect(result[6]).toBeCloseTo(4);
+        expect(result[7]).toBeCloseTo(5);
+        expect(result[8]).toBeCloseTo(6);
+        expect(result[9]).toBeCloseTo(7);
     });
 });

--- a/tests/System.test.ts
+++ b/tests/System.test.ts
@@ -85,7 +85,6 @@ describe("DiscreteSystem", () => {
         ).toThrowError("Number of particles should be an integer greater than or equal to 1, but is 3.1.");
     });
 
-
     test("throws expected error dt <= 0 or dt is Infinity", () => {
         expect(() =>
             System.createDiscrete<SIRShared, null, SIRData>(
@@ -93,7 +92,7 @@ describe("DiscreteSystem", () => {
                 sirShared,
                 5, // time
                 -1, // dt
-                3, // nParticles
+                3 // nParticles
             )
         ).toThrowError("dt provided, -1, must be positive and finite");
 
@@ -103,7 +102,7 @@ describe("DiscreteSystem", () => {
                 sirShared,
                 5, // time
                 Infinity, // dt
-                3, // nParticles
+                3 // nParticles
             )
         ).toThrowError("dt provided, Infinity, must be positive and finite");
     });

--- a/tests/System.test.ts
+++ b/tests/System.test.ts
@@ -85,6 +85,29 @@ describe("DiscreteSystem", () => {
         ).toThrowError("Number of particles should be an integer greater than or equal to 1, but is 3.1.");
     });
 
+
+    test("throws expected error dt <= 0 or dt is Infinity", () => {
+        expect(() =>
+            System.createDiscrete<SIRShared, null, SIRData>(
+                generator,
+                sirShared,
+                5, // time
+                -1, // dt
+                3, // nParticles
+            )
+        ).toThrowError("dt provided, -1, must be positive and finite");
+
+        expect(() =>
+            System.createDiscrete<SIRShared, null, SIRData>(
+                generator,
+                sirShared,
+                5, // time
+                Infinity, // dt
+                3, // nParticles
+            )
+        ).toThrowError("dt provided, Infinity, must be positive and finite");
+    });
+
     const expectParticleGroupState = (
         sys: System<any, any, any>,
         iGroup: number,

--- a/tests/examples/constantGradNoUpdate.ts
+++ b/tests/examples/constantGradNoUpdate.ts
@@ -31,7 +31,7 @@ export const constantGradNoUpdate: ContinuousGeneratorODE<ConstantGradNoUpdateSh
             ["Y", []],
             ["Y + 1", []]
         ]);
-        return new Packer({ shape, nRhsVariables: 1 });
+        return new Packer({ shape });
     },
 
     updateShared(shared, newShared) {

--- a/tests/examples/constantGradNoUpdate.ts
+++ b/tests/examples/constantGradNoUpdate.ts
@@ -1,0 +1,41 @@
+import { ContinuousGeneratorODE } from "../../src/interfaces/generators/ContinuousGenerator.ts";
+import { Packer } from "../../src/Packer.ts";
+
+export interface ConstantGradNoUpdateShared {
+    y: number;
+    yAddOne: number;
+}
+
+export const constantGradNoUpdate: ContinuousGeneratorODE<ConstantGradNoUpdateShared, null, null> = {
+    initial(time: number, shared, internal: null, stateNext: number[]) {
+        stateNext[0] = shared.y;
+        stateNext[1] = shared.yAddOne;
+    },
+
+    rhs(t, y, dydt) {
+        dydt[0] = 1;
+    },
+
+    output(t, y) {
+        const output = Array(1);
+        output[0] = y[0] + 1;
+        return output;
+    },
+
+    internal(): null {
+        return null;
+    },
+
+    packingState(): Packer {
+        const shape = new Map<string, number[]>([
+            ["Y", []],
+            ["Y + 1", []]
+        ]);
+        return new Packer({ shape, nRhsVariables: 1 });
+    },
+
+    updateShared(shared, newShared) {
+        shared.y = newShared.y;
+        shared.yAddOne = newShared.yAddOne;
+    }
+};


### PR DESCRIPTION
This PR adds the optimised mode in running particles where the solver can pick its own dt and integrate the ODE without being throttled by the user's choice of dt

this is only valid when the user doesnt provide time specific updates through the zeroEvery or update methods in the generator