### PR TITLE
Mrc 6697 Add DDE support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
             "name": "dust2",
             "version": "0.0.1",
             "dependencies": {
+                "@reside-ic/dopri": "^1.0.1",
                 "@reside-ic/random": "^1.0.0",
-                "dopri": "file:../dopri-js/",
                 "ieee745gamma": "^1.0.1",
                 "ndarray": "^1.0.19"
             },
@@ -30,7 +30,9 @@
             }
         },
         "../dopri-js": {
-            "version": "1.0.0",
+            "name": "@reside-ic/dopri",
+            "version": "1.0.1",
+            "extraneous": true,
             "license": "MIT",
             "devDependencies": {
                 "@vitest/coverage-istanbul": "^3.0.5",
@@ -333,14 +335,13 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-            "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+            "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "aix"
@@ -350,14 +351,13 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-            "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+            "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -367,14 +367,13 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-            "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+            "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -384,14 +383,13 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-            "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+            "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -401,14 +399,13 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-            "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+            "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -418,14 +415,13 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-            "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+            "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -435,14 +431,13 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+            "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -452,14 +447,13 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-            "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+            "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -469,14 +463,13 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-            "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+            "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -486,14 +479,13 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-            "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+            "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -503,14 +495,13 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-            "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+            "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -520,14 +511,13 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-            "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+            "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
             "cpu": [
                 "loong64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -537,14 +527,13 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-            "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+            "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
             "cpu": [
                 "mips64el"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -554,14 +543,13 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-            "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+            "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -571,14 +559,13 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-            "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+            "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -588,14 +575,13 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-            "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+            "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -605,14 +591,13 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-            "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+            "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -622,14 +607,13 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+            "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
@@ -639,14 +623,13 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-            "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+            "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
@@ -656,14 +639,13 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+            "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
@@ -673,14 +655,13 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-            "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+            "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
@@ -689,15 +670,30 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+            "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-            "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+            "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "sunos"
@@ -707,14 +703,13 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-            "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+            "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -724,14 +719,13 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-            "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+            "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -741,14 +735,13 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-            "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+            "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1263,6 +1256,11 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@reside-ic/dopri": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@reside-ic/dopri/-/dopri-1.0.1.tgz",
+            "integrity": "sha512-bUPnFUQ6dwhcp58Zl5y0zy7lxGFNFLUXO1cmIqq3oiNcgISclQb4dv5MOo09Ct9WEqvSU1uY+R93j6R6ipFV6A=="
+        },
         "node_modules/@reside-ic/random": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@reside-ic/random/-/random-1.0.0.tgz",
@@ -1325,252 +1323,286 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.27.4.tgz",
-            "integrity": "sha512-2Y3JT6f5MrQkICUyRVCw4oa0sutfAsgaSsb0Lmmy1Wi2y7X5vT9Euqw4gOsCyy0YfKURBg35nhUKZS4mDcfULw==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+            "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.27.4.tgz",
-            "integrity": "sha512-wzKRQXISyi9UdCVRqEd0H4cMpzvHYt1f/C3CoIjES6cG++RHKhrBj2+29nPF0IB5kpy9MS71vs07fvrNGAl/iA==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+            "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.4.tgz",
-            "integrity": "sha512-PlNiRQapift4LNS8DPUHuDX/IdXiLjf8mc5vdEmUR0fF/pyy2qWwzdLjB+iZquGr8LuN4LnUoSEvKRwjSVYz3Q==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+            "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.27.4.tgz",
-            "integrity": "sha512-o9bH2dbdgBDJaXWJCDTNDYa171ACUdzpxSZt+u/AAeQ20Nk5x+IhA+zsGmrQtpkLiumRJEYef68gcpn2ooXhSQ==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+            "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.27.4.tgz",
-            "integrity": "sha512-NBI2/i2hT9Q+HySSHTBh52da7isru4aAAo6qC3I7QFVsuhxi2gM8t/EI9EVcILiHLj1vfi+VGGPaLOUENn7pmw==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+            "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.27.4.tgz",
-            "integrity": "sha512-wYcC5ycW2zvqtDYrE7deary2P2UFmSh85PUpAx+dwTCO9uw3sgzD6Gv9n5X4vLaQKsrfTSZZ7Z7uynQozPVvWA==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+            "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.27.4.tgz",
-            "integrity": "sha512-9OwUnK/xKw6DyRlgx8UizeqRFOfi9mf5TYCw1uolDaJSbUmBxP85DE6T4ouCMoN6pXw8ZoTeZCSEfSaYo+/s1w==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+            "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.27.4.tgz",
-            "integrity": "sha512-Vgdo4fpuphS9V24WOV+KwkCVJ72u7idTgQaBoLRD0UxBAWTF9GWurJO9YD9yh00BzbkhpeXtm6na+MvJU7Z73A==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+            "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.27.4.tgz",
-            "integrity": "sha512-pleyNgyd1kkBkw2kOqlBx+0atfIIkkExOTiifoODo6qKDSpnc6WzUY5RhHdmTdIJXBdSnh6JknnYTtmQyobrVg==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+            "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.27.4.tgz",
-            "integrity": "sha512-caluiUXvUuVyCHr5DxL8ohaaFFzPGmgmMvwmqAITMpV/Q+tPoaHZ/PWa3t8B2WyoRcIIuu1hkaW5KkeTDNSnMA==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+            "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.27.4.tgz",
-            "integrity": "sha512-FScrpHrO60hARyHh7s1zHE97u0KlT/RECzCKAdmI+LEoC1eDh/RDji9JgFqyO+wPDb86Oa/sXkily1+oi4FzJQ==",
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+            "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+            "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.27.4.tgz",
-            "integrity": "sha512-qyyprhyGb7+RBfMPeww9FlHwKkCXdKHeGgSqmIXw9VSUtvyFZ6WZRtnxgbuz76FK7LyoN8t/eINRbPUcvXB5fw==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+            "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
-            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+            "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.27.4.tgz",
-            "integrity": "sha512-PFz+y2kb6tbh7m3A7nA9++eInGcDVZUACulf/KzDtovvdTizHpZaJty7Gp0lFwSQcrnebHOqxF1MaKZd7psVRg==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+            "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.27.4.tgz",
-            "integrity": "sha512-Ni8mMtfo+o/G7DVtweXXV/Ol2TFf63KYjTtoZ5f078AUgJTmaIJnj4JFU7TK/9SVWTaSJGxPi5zMDgK4w+Ez7Q==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+            "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.27.4.tgz",
-            "integrity": "sha512-5AeeAF1PB9TUzD+3cROzFTnAJAcVUGLuR8ng0E0WXGkYhp6RD6L+6szYVX+64Rs0r72019KHZS1ka1q+zU/wUw==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+            "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.27.4.tgz",
-            "integrity": "sha512-yOpVsA4K5qVwu2CaS3hHxluWIK5HQTjNV4tWjQXluMiiiu4pJj4BN98CvxohNCpcjMeTXk/ZMJBRbgRg8HBB6A==",
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+            "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+            "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.27.4.tgz",
-            "integrity": "sha512-KtwEJOaHAVJlxV92rNYiG9JQwQAdhBlrjNRp7P9L8Cb4Rer3in+0A+IPhJC9y68WAi9H0sX4AiG2NTsVlmqJeQ==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+            "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
-            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+            "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.27.4.tgz",
-            "integrity": "sha512-3j4jx1TppORdTAoBJRd+/wJRGCPC0ETWkXOecJ6PPZLj6SptXkrXcNqdj0oclbKML6FkQltdz7bBA3rUSirZug==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+            "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1782,11 +1814,10 @@
             "license": "MIT"
         },
         "node_modules/@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true
         },
         "node_modules/@types/hast": {
             "version": "3.0.4",
@@ -2673,10 +2704,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/dopri": {
-            "resolved": "../dopri-js",
-            "link": true
-        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2719,12 +2746,11 @@
             "license": "MIT"
         },
         "node_modules/esbuild": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-            "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+            "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -2732,31 +2758,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.24.2",
-                "@esbuild/android-arm": "0.24.2",
-                "@esbuild/android-arm64": "0.24.2",
-                "@esbuild/android-x64": "0.24.2",
-                "@esbuild/darwin-arm64": "0.24.2",
-                "@esbuild/darwin-x64": "0.24.2",
-                "@esbuild/freebsd-arm64": "0.24.2",
-                "@esbuild/freebsd-x64": "0.24.2",
-                "@esbuild/linux-arm": "0.24.2",
-                "@esbuild/linux-arm64": "0.24.2",
-                "@esbuild/linux-ia32": "0.24.2",
-                "@esbuild/linux-loong64": "0.24.2",
-                "@esbuild/linux-mips64el": "0.24.2",
-                "@esbuild/linux-ppc64": "0.24.2",
-                "@esbuild/linux-riscv64": "0.24.2",
-                "@esbuild/linux-s390x": "0.24.2",
-                "@esbuild/linux-x64": "0.24.2",
-                "@esbuild/netbsd-arm64": "0.24.2",
-                "@esbuild/netbsd-x64": "0.24.2",
-                "@esbuild/openbsd-arm64": "0.24.2",
-                "@esbuild/openbsd-x64": "0.24.2",
-                "@esbuild/sunos-x64": "0.24.2",
-                "@esbuild/win32-arm64": "0.24.2",
-                "@esbuild/win32-ia32": "0.24.2",
-                "@esbuild/win32-x64": "0.24.2"
+                "@esbuild/aix-ppc64": "0.25.10",
+                "@esbuild/android-arm": "0.25.10",
+                "@esbuild/android-arm64": "0.25.10",
+                "@esbuild/android-x64": "0.25.10",
+                "@esbuild/darwin-arm64": "0.25.10",
+                "@esbuild/darwin-x64": "0.25.10",
+                "@esbuild/freebsd-arm64": "0.25.10",
+                "@esbuild/freebsd-x64": "0.25.10",
+                "@esbuild/linux-arm": "0.25.10",
+                "@esbuild/linux-arm64": "0.25.10",
+                "@esbuild/linux-ia32": "0.25.10",
+                "@esbuild/linux-loong64": "0.25.10",
+                "@esbuild/linux-mips64el": "0.25.10",
+                "@esbuild/linux-ppc64": "0.25.10",
+                "@esbuild/linux-riscv64": "0.25.10",
+                "@esbuild/linux-s390x": "0.25.10",
+                "@esbuild/linux-x64": "0.25.10",
+                "@esbuild/netbsd-arm64": "0.25.10",
+                "@esbuild/netbsd-x64": "0.25.10",
+                "@esbuild/openbsd-arm64": "0.25.10",
+                "@esbuild/openbsd-x64": "0.25.10",
+                "@esbuild/openharmony-arm64": "0.25.10",
+                "@esbuild/sunos-x64": "0.25.10",
+                "@esbuild/win32-arm64": "0.25.10",
+                "@esbuild/win32-ia32": "0.25.10",
+                "@esbuild/win32-x64": "0.25.10"
             }
         },
         "node_modules/escalade": {
@@ -3882,9 +3909,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "dev": true,
             "funding": [
                 {
@@ -3892,7 +3919,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -4109,9 +4135,9 @@
             "license": "MIT"
         },
         "node_modules/postcss": {
-            "version": "8.4.49",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+            "version": "8.5.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
             "dev": true,
             "funding": [
                 {
@@ -4127,9 +4153,8 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.7",
+                "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -4274,13 +4299,12 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.27.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.27.4.tgz",
-            "integrity": "sha512-RLKxqHEMjh/RGLsDxAEsaLO3mWgyoU6x9w6n1ikAzet4B3gI2/3yP6PWY2p9QzRTh6MfEIXB3MwsOY0Iv3vNrw==",
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+            "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.6"
+                "@types/estree": "1.0.8"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -4290,24 +4314,28 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.27.4",
-                "@rollup/rollup-android-arm64": "4.27.4",
-                "@rollup/rollup-darwin-arm64": "4.27.4",
-                "@rollup/rollup-darwin-x64": "4.27.4",
-                "@rollup/rollup-freebsd-arm64": "4.27.4",
-                "@rollup/rollup-freebsd-x64": "4.27.4",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.27.4",
-                "@rollup/rollup-linux-arm-musleabihf": "4.27.4",
-                "@rollup/rollup-linux-arm64-gnu": "4.27.4",
-                "@rollup/rollup-linux-arm64-musl": "4.27.4",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.27.4",
-                "@rollup/rollup-linux-riscv64-gnu": "4.27.4",
-                "@rollup/rollup-linux-s390x-gnu": "4.27.4",
-                "@rollup/rollup-linux-x64-gnu": "4.27.4",
-                "@rollup/rollup-linux-x64-musl": "4.27.4",
-                "@rollup/rollup-win32-arm64-msvc": "4.27.4",
-                "@rollup/rollup-win32-ia32-msvc": "4.27.4",
-                "@rollup/rollup-win32-x64-msvc": "4.27.4",
+                "@rollup/rollup-android-arm-eabi": "4.52.2",
+                "@rollup/rollup-android-arm64": "4.52.2",
+                "@rollup/rollup-darwin-arm64": "4.52.2",
+                "@rollup/rollup-darwin-x64": "4.52.2",
+                "@rollup/rollup-freebsd-arm64": "4.52.2",
+                "@rollup/rollup-freebsd-x64": "4.52.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+                "@rollup/rollup-linux-arm64-musl": "4.52.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+                "@rollup/rollup-linux-x64-gnu": "4.52.2",
+                "@rollup/rollup-linux-x64-musl": "4.52.2",
+                "@rollup/rollup-openharmony-arm64": "4.52.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+                "@rollup/rollup-win32-x64-gnu": "4.52.2",
+                "@rollup/rollup-win32-x64-msvc": "4.52.2",
                 "fsevents": "~2.3.2"
             }
         },
@@ -4640,6 +4668,51 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/tinypool": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -4865,15 +4938,17 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.0.tgz",
-            "integrity": "sha512-Q2+5yQV79EdnpbNxjD3/QHVMCBaQ3Kpd4/uL51UGuh38bIIM+s4o3FqyCzRvTRwFb+cWIUeZvaWwS9y2LD2qeQ==",
+            "version": "6.3.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+            "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.24.0",
-                "postcss": "^8.4.49",
-                "rollup": "^4.23.0"
+                "esbuild": "^0.25.0",
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2",
+                "postcss": "^8.5.3",
+                "rollup": "^4.34.9",
+                "tinyglobby": "^0.2.13"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -5474,6 +5549,35 @@
                 "vite": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vite/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/vitest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@reside-ic/random": "^1.0.0",
-                "dopri": "^0.0.13",
+                "dopri": "file:../dopri-js/",
                 "ieee745gamma": "^1.0.1",
                 "ndarray": "^1.0.19"
             },
@@ -27,6 +27,21 @@
                 "vite": "^6.0.0",
                 "vite-plugin-dts": "^4.5.3",
                 "vitest": "^2.1.6"
+            }
+        },
+        "../dopri-js": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "devDependencies": {
+                "@vitest/coverage-istanbul": "^3.0.5",
+                "eslint": "^9.20.1",
+                "prettier": "^3.5.0",
+                "typedoc": "^0.27.7",
+                "typescript": "^5.7.3",
+                "typescript-eslint": "^8.24.0",
+                "vite": "^6.1.0",
+                "vite-plugin-dts": "^4.5.0",
+                "vitest": "^3.0.5"
             }
         },
         "../typedoc-plugin-copy-doc": {
@@ -2659,9 +2674,8 @@
             "license": "MIT"
         },
         "node_modules/dopri": {
-            "version": "0.0.13",
-            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.13.tgz",
-            "integrity": "sha512-rWUNSkKER/ok0GR8cwbN4fqo87Xd5/rWDHOrn8FnQHEg8wKChIzVA1vzZPNkVw1J5KGAh+LdaSUrBHGnHR4s1w=="
+            "resolved": "../dopri-js",
+            "link": true
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@reside-ic/random": "^1.0.0",
-        "dopri": "^0.0.13",
+        "dopri": "file:../dopri-js/",
         "ieee745gamma": "^1.0.1",
         "ndarray": "^1.0.19"
     },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
         "docs": "typedoc"
     },
     "dependencies": {
+        "@reside-ic/dopri": "^1.0.1",
         "@reside-ic/random": "^1.0.0",
-        "dopri": "file:../dopri-js/",
         "ieee745gamma": "^1.0.1",
         "ndarray": "^1.0.19"
     },

--- a/src/System.ts
+++ b/src/System.ts
@@ -1,5 +1,5 @@
 import ndarray from "ndarray";
-import * as dopri from "dopri";
+import * as dopri from "@reside-ic/dopri";
 import { Random, RngStateBuiltin } from "@reside-ic/random";
 import { ParticleState, SystemState, SystemSubState } from "./SystemState.ts";
 import { Packer } from "./Packer.ts";

--- a/tests/ContinuousSystem.test.ts
+++ b/tests/ContinuousSystem.test.ts
@@ -2,26 +2,7 @@ import { describe, test, expect, vi, afterEach } from "vitest";
 import { System } from "../src/System.ts";
 import { constantGrad, ConstantGradShared } from "./examples/constantGrad.ts";
 import { constantGradNoUpdate, ConstantGradNoUpdateShared } from "./examples/constantGradNoUpdate.ts";
-
-const createSystem = (shared: ConstantGradShared) =>
-    System.createODE<ConstantGradShared, null>(
-        constantGrad,
-        [shared],
-        5, // time
-        0.001, // dt
-        1, // nParticles
-        undefined
-    );
-
-const createSystemNoUpdate = (shared: ConstantGradNoUpdateShared) =>
-    System.createODE<ConstantGradNoUpdateShared, null>(
-        constantGradNoUpdate,
-        [shared],
-        5, // time
-        0.001, // dt
-        1, // nParticles
-        undefined
-    );
+import { constantGradDelay, ConstantGradDelayShared } from "./examples/constantGradDelay.ts";
 
 describe("ContinuousSystem", () => {
     afterEach(() => {
@@ -29,7 +10,15 @@ describe("ContinuousSystem", () => {
     });
 
     test("Can initialise and run to time using constantGrad generator", () => {
-        const sys = createSystem({ y: 1, yAddOne: 2 });
+        const shared = { y: 1, yAddOne: 2 };
+        const sys = System.createODE<ConstantGradShared, null>(
+            constantGrad,
+            [shared],
+            5, // time
+            0.001, // dt
+            1, // nParticles
+            undefined
+        );
         sys.setStateInitial();
         const result = sys.simulate([6, 7, 8, 9, 10]).resultValues().data;
 
@@ -49,7 +38,15 @@ describe("ContinuousSystem", () => {
     });
 
     test("Can initialise and run to time using constantGradNoUpdate generator", () => {
-        const sys = createSystemNoUpdate({ y: 1, yAddOne: 2 });
+        const shared = { y: 1, yAddOne: 2 };
+        const sys = System.createODE<ConstantGradNoUpdateShared, null>(
+            constantGradNoUpdate,
+            [shared],
+            5, // time
+            0.001, // dt
+            1, // nParticles
+            undefined
+        );
         sys.setStateInitial();
         const result = sys.simulate([6, 7, 8, 9, 10]).resultValues().data;
 
@@ -66,5 +63,55 @@ describe("ContinuousSystem", () => {
         expect(result[7]).toBeCloseTo(5);
         expect(result[8]).toBeCloseTo(6);
         expect(result[9]).toBeCloseTo(7);
+    });
+
+    test("Can initialise and run to time using constantGradDelay generator", () => {
+        const shared = { m: 1, x: 1, c: 1, y: 1, yDelay1: 1 };
+        const sys = System.createDDE<ConstantGradDelayShared, null>(
+            constantGradDelay,
+            [shared],
+            5, // time
+            0.001, // dt
+            1, // nParticles
+            undefined
+        );
+        sys.setStateInitial();
+        // discontinuities occur at every even time (c reset to zero) and t = 8 (m set to 100)
+        // so let's avoid those for now in testing, it will require more thought
+        const result = sys.simulate([6.5, 7.5, 8.5, 9.5]).resultValues().data;
+
+        // m
+        expect(result[0]).toBeCloseTo(1);
+        expect(result[1]).toBeCloseTo(1);
+        expect(result[2]).toBeCloseTo(100); // m gets updated to 100 at t = 8
+        expect(result[3]).toBeCloseTo(100);
+
+        // x
+        expect(result[4]).toBeCloseTo(2.5); // start at x = 1 and dxdt = 1
+        expect(result[5]).toBeCloseTo(3.5);
+        expect(result[6]).toBeCloseTo(4.5);
+        expect(result[7]).toBeCloseTo(5.5);
+
+        // c
+        // start at c = 1 and dcdt = 1 and c is reset on even times
+        expect(result[8]).toBeCloseTo(0.5);
+        expect(result[9]).toBeCloseTo(1.5);
+        expect(result[10]).toBeCloseTo(0.5);
+        expect(result[11]).toBeCloseTo(1.5);
+
+        // y
+        // y = mx + c
+        expect(result[12]).toBeCloseTo(3);
+        expect(result[13]).toBeCloseTo(5);
+        expect(result[14]).toBeCloseTo(450.5);
+        expect(result[15]).toBeCloseTo(551.5);
+
+        // y delayed by 1
+        // first delayed values corresponds to y value at t = 5.5 which would have
+        // m = 1, x = 1.5, c = 1.5
+        expect(result[16]).toBeCloseTo(3);
+        expect(result[17]).toBeCloseTo(3);
+        expect(result[18]).toBeCloseTo(5);
+        expect(result[19]).toBeCloseTo(450.5);
     });
 });

--- a/tests/examples/constantGradDelay.ts
+++ b/tests/examples/constantGradDelay.ts
@@ -28,10 +28,6 @@ export const constantGradDelay: ContinuousGeneratorDDE<ConstantGradDelayShared, 
         const output = Array(2);
         output[0] = y[0] * y[1] + y[2];
         const [mDelay, xDelay, cDelay] = solution(t - 1);
-        if (Math.abs(t - 8.5) < 1e-10) {
-            console.log(t - 1);
-            console.log(mDelay, xDelay, cDelay);
-        }
         output[1] = mDelay * xDelay + cDelay;
         return output;
     },

--- a/tests/examples/constantGradDelay.ts
+++ b/tests/examples/constantGradDelay.ts
@@ -1,0 +1,71 @@
+import { ContinuousGeneratorDDE } from "../../src/interfaces/generators/ContinuousGenerator.ts";
+import { Packer } from "../../src/Packer.ts";
+
+export interface ConstantGradDelayShared {
+    m: number;
+    x: number;
+    c: number;
+    y: number;
+    yDelay1: number;
+}
+
+export const constantGradDelay: ContinuousGeneratorDDE<ConstantGradDelayShared, null, null> = {
+    initial(time: number, shared, internal: null, stateNext: number[]) {
+        stateNext[0] = shared.m;
+        stateNext[1] = shared.x;
+        stateNext[2] = shared.c;
+        stateNext[3] = shared.y;
+        stateNext[4] = shared.yDelay1;
+    },
+
+    rhs(t, y, dydt) {
+        dydt[0] = 0;
+        dydt[1] = 1;
+        dydt[2] = 1;
+    },
+
+    output(t, y, solution) {
+        const output = Array(2);
+        output[0] = y[0] * y[1] + y[2];
+        const [mDelay, xDelay, cDelay] = solution(t - 1);
+        if (Math.abs(t - 8.5) < 1e-10) {
+            console.log(t - 1);
+            console.log(mDelay, xDelay, cDelay);
+        }
+        output[1] = mDelay * xDelay + cDelay;
+        return output;
+    },
+
+    update(time: number, dt: number, state: number[], shared, internal: null, stateNext: number[]) {
+        if (Math.abs(time - 8) < 1e-10) {
+            stateNext[0] = 100;
+        }
+    },
+
+    getZeroEvery() {
+        return [[2, [2]]];
+    },
+
+    internal(): null {
+        return null;
+    },
+
+    packingState(): Packer {
+        const shape = new Map<string, number[]>([
+            ["gradient", []],
+            ["X", []],
+            ["intercept", []],
+            ["Y", []],
+            ["Y delayed by 1", []]
+        ]);
+        return new Packer({ shape, nRhsVariables: 3 });
+    },
+
+    updateShared(shared, newShared) {
+        shared.m = newShared.m;
+        shared.x = newShared.x;
+        shared.c = newShared.c;
+        shared.y = newShared.y;
+        shared.yDelay1 = newShared.yDelay1;
+    }
+};


### PR DESCRIPTION
This PR adds DDE support. Because of the `runParticleWithDt` path, we need to remember the past history to let the solver feed in the correct values for the delayed solutions, otherwise it will not remember the values past a `dt` time window

some dopri changes make the history public and we can get it and manage the history ourselves