### PR TITLE
Release v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "dust2",
-    "version": "0.0.1",
+    "name": "@reside-ic/dust2",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "dust2",
-            "version": "0.0.1",
+            "name": "@reside-ic/dust2",
+            "version": "1.0.0",
             "dependencies": {
                 "@reside-ic/dopri": "^1.0.1",
                 "@reside-ic/random": "^1.0.0",
@@ -17,10 +17,12 @@
                 "@eslint/js": "^9.15.0",
                 "@reside-ic/typedoc-plugin-copy-doc": "^1.1.2",
                 "@types/ndarray": "^1.0.14",
+                "@types/node": "^25.7.0",
                 "@vitest/coverage-istanbul": "^2.1.8",
                 "eslint": "^9.15.0",
                 "globals": "^15.12.0",
                 "prettier": "^3.4.2",
+                "tsx": "^4.22.0",
                 "typedoc": "^0.27.9",
                 "typescript": "~5.6.2",
                 "typescript-eslint": "^8.16.0",
@@ -1915,6 +1917,16 @@
             "integrity": "sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "25.7.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+            "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.21.0"
+            }
         },
         "node_modules/@types/unist": {
             "version": "3.0.3",
@@ -4863,6 +4875,509 @@
                 "typescript": ">=4.2.0"
             }
         },
+        "node_modules/tsx": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
+            "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "~0.28.0"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/esbuild": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.0",
+                "@esbuild/android-arm": "0.28.0",
+                "@esbuild/android-arm64": "0.28.0",
+                "@esbuild/android-x64": "0.28.0",
+                "@esbuild/darwin-arm64": "0.28.0",
+                "@esbuild/darwin-x64": "0.28.0",
+                "@esbuild/freebsd-arm64": "0.28.0",
+                "@esbuild/freebsd-x64": "0.28.0",
+                "@esbuild/linux-arm": "0.28.0",
+                "@esbuild/linux-arm64": "0.28.0",
+                "@esbuild/linux-ia32": "0.28.0",
+                "@esbuild/linux-loong64": "0.28.0",
+                "@esbuild/linux-mips64el": "0.28.0",
+                "@esbuild/linux-ppc64": "0.28.0",
+                "@esbuild/linux-riscv64": "0.28.0",
+                "@esbuild/linux-s390x": "0.28.0",
+                "@esbuild/linux-x64": "0.28.0",
+                "@esbuild/netbsd-arm64": "0.28.0",
+                "@esbuild/netbsd-x64": "0.28.0",
+                "@esbuild/openbsd-arm64": "0.28.0",
+                "@esbuild/openbsd-x64": "0.28.0",
+                "@esbuild/openharmony-arm64": "0.28.0",
+                "@esbuild/sunos-x64": "0.28.0",
+                "@esbuild/win32-arm64": "0.28.0",
+                "@esbuild/win32-ia32": "0.28.0",
+                "@esbuild/win32-x64": "0.28.0"
+            }
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4977,6 +5492,13 @@
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
             "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/undici-types": {
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+            "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,24 @@
 {
-    "name": "dust2",
-    "version": "0.0.1",
+    "name": "@reside-ic/dust2",
+    "version": "1.0.0",
     "type": "module",
+    "files": [
+        "dist"
+    ],
+    "main": "./dist/dust2.umd.cjs",
+    "module": "./dist/dust2.js",
+    "types": "./dist/dust2.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./dist/dust2.d.ts",
+                "default": "./dist/dust2.js"
+            },
+            "require": "./dist/dust2.umd.cjs"
+        }
+    },
     "scripts": {
-        "build": "tsc && vite build",
+        "build": "tsc && vite build && tsx scripts/renameModuleDeclaration.ts",
         "lint": "eslint",
         "format-check": "npx prettier . --check",
         "format-write": "npx prettier . --write",
@@ -21,10 +36,12 @@
         "@eslint/js": "^9.15.0",
         "@reside-ic/typedoc-plugin-copy-doc": "^1.1.2",
         "@types/ndarray": "^1.0.14",
+        "@types/node": "^25.7.0",
         "@vitest/coverage-istanbul": "^2.1.8",
         "eslint": "^9.15.0",
         "globals": "^15.12.0",
         "prettier": "^3.4.2",
+        "tsx": "^4.22.0",
         "typedoc": "^0.27.9",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.16.0",

--- a/scripts/renameModuleDeclaration.ts
+++ b/scripts/renameModuleDeclaration.ts
@@ -1,0 +1,19 @@
+// This script will get executed when running `npm run build` because vue-tsc
+// outputs a declaration file that contains `declare module "index"`
+// (based off the file name) however our package is called
+// @reside-ic/dust2 so we need to fix the name of the declared module
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const declarationFile = join(__dirname, "..", "dist", "dust2.d.ts");
+
+const declarationFileContents = readFileSync(declarationFile, "utf-8");
+
+const newFileContents = declarationFileContents.replace('declare module "index"', 'declare module "@reside-ic/dust2"');
+
+writeFileSync(declarationFile, newFileContents);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,14 +6,16 @@
         "lib": ["ESNext", "ESNext.Array"],
         "skipLibCheck": true,
         "declaration": true,
-        "outDir": "./lib",
+        "emitDeclarationOnly": true,
+        "outDir": "./dist",
+        "outFile": "./dist/dust2",
+        "types": ["node"],
 
         /* Bundler mode */
         "moduleResolution": "Bundler",
         "allowImportingTsExtensions": true,
-        "isolatedModules": true,
         "moduleDetection": "force",
-        "noEmit": true,
+        "noEmit": false,
 
         /* Linting */
         "strict": true,
@@ -22,5 +24,6 @@
         "noFallthroughCasesInSwitch": true,
         "noUncheckedSideEffectImports": true
     },
-    "include": ["src"]
+    "include": ["src"],
+    "files": ["src/index.ts"]
 }


### PR DESCRIPTION
Got this package on npm with a similar build process as skadi chart (which resolves troubles around package being called `@reside-ic/dust2` instead of `dust2`)