### PR TITLE
Remove groups

### DIFF
--- a/src/System.ts
+++ b/src/System.ts
@@ -36,7 +36,7 @@ export class System<TParams, TInternal, TData> implements SystemInterface<TData>
     protected readonly _zeroEvery: ZeroEvery;
     protected readonly _random: Random;
     protected _time: number;
-    protected _solvers: dopri.Dopri[] | dopri.DDE[] | null[];
+    protected _solver: dopri.Dopri | dopri.DDE | null = null;
     protected _rhsVariablesLength: number;
     protected _history: dopri.History[];
 
@@ -73,7 +73,6 @@ export class System<TParams, TInternal, TData> implements SystemInterface<TData>
         this._params = params;
         this._internal = generator.internal(imports, params);
         this._zeroEvery = generator.getZeroEvery ? generator.getZeroEvery!(imports, params) : [];
-        this._solvers = Array(nParticles).fill(null);
         this._history = Array(nParticles).fill([]);
 
         const nVariables = this._statePacker.nVariables;
@@ -191,34 +190,30 @@ export class System<TParams, TInternal, TData> implements SystemInterface<TData>
      * Dopri solvers if this is a continuous system.
      */
     public setStateInitial(): void {
+        const { generator, isContinuous, hasDelays } = this._generatorCfg;
+        if (isContinuous) {
+            if (hasDelays) {
+                const generatorRhs = generator.rhs.bind(null, imports);
+                const generatorOutput = generator.output?.bind(null, imports);
+                this._solver = new dopri.DDE(
+                    generatorRhs,
+                    this._rhsVariablesLength,
+                    // these are the control params which will be added in a future ticket: mrc-6742
+                    // https://mrc-ide.github.io/dopri-js/interfaces/DopriControlParam.html
+                    {},
+                    generatorOutput
+                );
+            } else {
+                const generatorRhs = generator.rhs.bind(null, imports);
+                const generatorOutput = generator.output?.bind(null, imports);
+                this._solver = new dopri.Dopri(generatorRhs, this._rhsVariablesLength, {}, generatorOutput);
+            }
+        }
+
         this.iterateParticles((iParticle) => {
             const state = this._state.getParticle(iParticle);
             const arrayState = particleStateToArray(state);
-            const { generator, isContinuous, hasDelays } = this._generatorCfg;
             generator.initial(imports, this._time, this._params, this._internal, arrayState, this._random);
-            if (isContinuous) {
-                if (hasDelays) {
-                    const generatorRhs = generator.rhs.bind(null, imports);
-                    const generatorOutput = generator.output?.bind(null, imports);
-                    this._solvers[iParticle] = new dopri.DDE(
-                        generatorRhs,
-                        this._rhsVariablesLength,
-                        // these are the control params which will be added in a future ticket: mrc-6742
-                        // https://mrc-ide.github.io/dopri-js/interfaces/DopriControlParam.html
-                        {},
-                        generatorOutput
-                    );
-                } else {
-                    const generatorRhs = generator.rhs.bind(null, imports);
-                    const generatorOutput = generator.output?.bind(null, imports);
-                    this._solvers[iParticle] = new dopri.Dopri(
-                        generatorRhs,
-                        this._rhsVariablesLength,
-                        {},
-                        generatorOutput
-                    );
-                }
-            }
             this._state.setParticle(iParticle, arrayState);
         });
     }
@@ -246,8 +241,7 @@ export class System<TParams, TInternal, TData> implements SystemInterface<TData>
         }
         const nSteps = (time - this._time) / this._dt;
         this.iterateParticles((iParticle) => {
-            const solver = this._solvers[iParticle];
-            const state = this.runParticle(this._state.getParticle(iParticle), nSteps, solver, time, iParticle);
+            const state = this.runParticle(this._state.getParticle(iParticle), nSteps, time, iParticle);
             this._state.setParticle(iParticle, state);
         });
         this._time = time;
@@ -279,12 +273,7 @@ export class System<TParams, TInternal, TData> implements SystemInterface<TData>
         return result;
     }
 
-    private runParticleWithDt(
-        particleState: ParticleState,
-        nSteps: number,
-        solver: dopri.Dopri | dopri.DDE | null,
-        iParticle: number
-    ): number[] {
+    private runParticleWithDt(particleState: ParticleState, nSteps: number, iParticle: number): number[] {
         let state = particleStateToArray(particleState);
         let stateNext = [...state];
         let time = this._time;
@@ -295,17 +284,17 @@ export class System<TParams, TInternal, TData> implements SystemInterface<TData>
                 }
             });
             const nextTime = time + this._dt;
-            if (solver) {
+            if (this._solver) {
                 const history = this._history[iParticle];
                 if (this._generatorCfg.hasDelays) {
-                    solver.initialise(time, state.slice(0, this._rhsVariablesLength), history);
+                    this._solver.initialise(time, state.slice(0, this._rhsVariablesLength), history);
                 } else {
-                    solver.initialise(time, state.slice(0, this._rhsVariablesLength));
+                    this._solver.initialise(time, state.slice(0, this._rhsVariablesLength));
                 }
-                const solution = solver.run(nextTime);
+                const solution = this._solver.run(nextTime);
                 state = solution([nextTime])[0];
                 stateNext = [...state];
-                this._history[iParticle] = history.concat(solver.getHistory());
+                this._history[iParticle] = history.concat(this._solver.getHistory());
             }
             const { update } = this._generatorCfg.generator;
             if (update) {
@@ -319,31 +308,23 @@ export class System<TParams, TInternal, TData> implements SystemInterface<TData>
         return state;
     }
 
-    private runParticleWithSolver(
-        particleState: ParticleState,
-        endTime: number,
-        solver: dopri.Dopri | dopri.DDE
-    ): number[] {
+    private runParticleWithSolver(particleState: ParticleState, endTime: number): number[] {
+        if (!this._solver) return [];
         const state = particleStateToArray(particleState);
-        solver.initialise(this._time, state.slice(0, this._rhsVariablesLength));
-        const solution = solver.run(endTime);
+        this._solver.initialise(this._time, state.slice(0, this._rhsVariablesLength));
+        const solution = this._solver.run(endTime);
         return solution([endTime])[0];
     }
 
-    private runParticle(
-        particleState: ParticleState,
-        nSteps: number,
-        solver: dopri.Dopri | dopri.DDE | null,
-        endTime: number,
-        iParticle: number
-    ): number[] {
+    private runParticle(particleState: ParticleState, nSteps: number, endTime: number, iParticle: number): number[] {
         const { isContinuous, generator } = this._generatorCfg;
-        const noUpdateOrZeroEvery = isContinuous && solver && !generator.update && !generator.getZeroEvery;
-        const invalidDt = isContinuous && solver && this._dt === 0;
+        const isContinuousSolver = isContinuous && this._solver;
+        const noUpdateOrZeroEvery = isContinuousSolver && !generator.update && !generator.getZeroEvery;
+        const invalidDt = isContinuousSolver && this._dt === 0;
         if (noUpdateOrZeroEvery || invalidDt) {
-            return this.runParticleWithSolver(particleState, endTime, solver);
+            return this.runParticleWithSolver(particleState, endTime);
         } else {
-            return this.runParticleWithDt(particleState, nSteps, solver, iParticle);
+            return this.runParticleWithDt(particleState, nSteps, iParticle);
         }
     }
 

--- a/src/System.ts
+++ b/src/System.ts
@@ -12,7 +12,6 @@ import {
     isPositiveFinite,
     particleStateToArray
 } from "./utils.ts";
-import { DustParameterError } from "./errors.ts";
 import { ZeroEvery } from "./zero.ts";
 import { SystemSimulateResult } from "./SystemSimulateResult.ts";
 import { GeneratorConfig } from "./interfaces/generators/Generator.ts";
@@ -26,25 +25,24 @@ import { imports } from "./interfaces/generators/Imports.ts";
  *
  * @copyDoc BaseGenerator
  */
-export class System<TShared, TInternal, TData> implements SystemInterface<TData> {
-    protected readonly _generatorCfg: GeneratorConfig<TShared, TInternal, TData>;
+export class System<TParams, TInternal, TData> implements SystemInterface<TData> {
+    protected readonly _generatorCfg: GeneratorConfig<TParams, TInternal, TData>;
     protected readonly _nParticles: number;
-    protected readonly _nGroups: number;
     protected readonly _statePacker: Packer;
     protected readonly _state: SystemState;
     protected readonly _dt: number;
-    protected _shared: TShared[];
-    protected readonly _internal: TInternal[];
-    protected readonly _zeroEvery: ZeroEvery[];
+    protected _params: TParams;
+    protected readonly _internal: TInternal;
+    protected readonly _zeroEvery: ZeroEvery;
     protected readonly _random: Random;
     protected _time: number;
-    protected _solvers: dopri.Dopri[][] | dopri.DDE[][] | null[][];
+    protected _solvers: dopri.Dopri[] | dopri.DDE[] | null[];
     protected _rhsVariablesLength: number;
-    protected _history: dopri.History[][];
+    protected _history: dopri.History[];
 
     private constructor(
-        generatorCfg: GeneratorConfig<TShared, TInternal, TData>,
-        shared: TShared[],
+        generatorCfg: GeneratorConfig<TParams, TInternal, TData>,
+        params: TParams,
         time: number,
         dt: number,
         nParticles: number,
@@ -68,18 +66,15 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
 
         this._time = time;
         this._nParticles = nParticles; // number of particles per parameter set
-        this._nGroups = shared.length; // number of parameter sets
-        this._statePacker = generator.packingState(imports, shared[0]);
+        this._statePacker = generator.packingState(imports, params);
         const nState = this._statePacker.length; // number of state elements in the packer, as defined by the generator
 
-        this._state = new SystemState(this._nGroups, this._nParticles, nState);
-        this._shared = shared;
-        this._internal = shared.map((s) => generator.internal(imports, s));
-        this._zeroEvery = generator.getZeroEvery
-            ? shared.map((s) => generator.getZeroEvery!(imports, s))
-            : shared.map(() => []);
-        this._solvers = shared.map(() => Array(nParticles).fill(null));
-        this._history = shared.map(() => Array(nParticles).fill([]));
+        this._state = new SystemState(this._nParticles, nState);
+        this._params = params;
+        this._internal = generator.internal(imports, params);
+        this._zeroEvery = generator.getZeroEvery ? generator.getZeroEvery!(imports, params) : [];
+        this._solvers = Array(nParticles).fill(null);
+        this._history = Array(nParticles).fill([]);
 
         const nVariables = this._statePacker.nVariables;
         const cleanNRhsVariables = nRhsVariables ?? nVariables;
@@ -89,30 +84,30 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
 
     /**
      * @param generator Discrete generator (model) implementation for the System
-     * @param shared Array of TShared, each representing the parameters for a group of particles
+     * @param params parameters of type TParams for a particle
      * @param time Initial time for the system
      * @param dt Time step to be used when updating the system, will error if dt <= 0 or dt is Infinity
-     * @param nParticles Number of particles per group
+     * @param nParticles Number of particles
      * @param nRhsVariables Number of variables to feed into the rhs function of the generator. This
      * may be less than the number of variables of the system if some variables are calculated from
      * the output function of the generator
      * @param random Random number generator which may be used by the generator
      */
-    static createDiscrete<TShared, TInternal, TData = null>(
-        generator: DiscreteGenerator<TShared, TInternal, TData>,
-        shared: TShared[],
+    static createDiscrete<TParams, TInternal, TData = null>(
+        generator: DiscreteGenerator<TParams, TInternal, TData>,
+        params: TParams,
         time: number,
         dt: number,
         nParticles: number,
         nRhsVariables?: number,
         random?: Random
     ) {
-        const generatorCfg: GeneratorConfig<TShared, TInternal, TData> = {
+        const generatorCfg: GeneratorConfig<TParams, TInternal, TData> = {
             generator,
             isContinuous: false,
             hasDelays: false
         };
-        return new System<TShared, TInternal, TData>(generatorCfg, shared, time, dt, nParticles, nRhsVariables, random);
+        return new System<TParams, TInternal, TData>(generatorCfg, params, time, dt, nParticles, nRhsVariables, random);
     }
 
     /**
@@ -124,42 +119,42 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
      * and let the solver run the continuous system.
      * @copyDoc System.createDiscrete
      */
-    static createODE<TShared, TInternal, TData = null>(
-        generator: ContinuousGeneratorODE<TShared, TInternal, TData>,
-        shared: TShared[],
+    static createODE<TParams, TInternal, TData = null>(
+        generator: ContinuousGeneratorODE<TParams, TInternal, TData>,
+        params: TParams,
         time: number,
         dt: number,
         nParticles: number,
         nRhsVariables?: number,
         random?: Random
     ) {
-        const generatorCfg: GeneratorConfig<TShared, TInternal, TData> = {
+        const generatorCfg: GeneratorConfig<TParams, TInternal, TData> = {
             generator,
             isContinuous: true,
             hasDelays: false
         };
-        return new System<TShared, TInternal, TData>(generatorCfg, shared, time, dt, nParticles, nRhsVariables, random);
+        return new System<TParams, TInternal, TData>(generatorCfg, params, time, dt, nParticles, nRhsVariables, random);
     }
 
     /**
      * @param generator Continuous DDE generator (model) implementation for the System
      * @copyDoc System.createODE
      */
-    static createDDE<TShared, TInternal, TData = null>(
-        generator: ContinuousGeneratorDDE<TShared, TInternal, TData>,
-        shared: TShared[],
+    static createDDE<TParams, TInternal, TData = null>(
+        generator: ContinuousGeneratorDDE<TParams, TInternal, TData>,
+        params: TParams,
         time: number,
         dt: number,
         nParticles: number,
         nRhsVariables?: number,
         random?: Random
     ) {
-        const generatorCfg: GeneratorConfig<TShared, TInternal, TData> = {
+        const generatorCfg: GeneratorConfig<TParams, TInternal, TData> = {
             generator,
             isContinuous: true,
             hasDelays: true
         };
-        return new System<TShared, TInternal, TData>(generatorCfg, shared, time, dt, nParticles, nRhsVariables, random);
+        return new System<TParams, TInternal, TData>(generatorCfg, params, time, dt, nParticles, nRhsVariables, random);
     }
 
     /**
@@ -185,11 +180,9 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
     }
 
     // helper method to iterate over all particles and execute the provided function
-    protected iterateParticles(f: (iGroup: number, iParticle: number) => void) {
-        for (let iGroup = 0; iGroup < this._nGroups; iGroup++) {
-            for (let iParticle = 0; iParticle < this._nParticles; iParticle++) {
-                f(iGroup, iParticle);
-            }
+    protected iterateParticles(f: (iParticle: number) => void) {
+        for (let iParticle = 0; iParticle < this._nParticles; iParticle++) {
+            f(iParticle);
         }
     }
 
@@ -198,18 +191,16 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
      * Dopri solvers if this is a continuous system.
      */
     public setStateInitial(): void {
-        this.iterateParticles((iGroup: number, iParticle: number) => {
-            const shared = this._shared[iGroup];
-            const internal = this._internal[iGroup];
-            const state = this._state.getParticle(iGroup, iParticle);
+        this.iterateParticles((iParticle) => {
+            const state = this._state.getParticle(iParticle);
             const arrayState = particleStateToArray(state);
             const { generator, isContinuous, hasDelays } = this._generatorCfg;
-            generator.initial(imports, this._time, shared, internal, arrayState, this._random);
+            generator.initial(imports, this._time, this._params, this._internal, arrayState, this._random);
             if (isContinuous) {
                 if (hasDelays) {
                     const generatorRhs = generator.rhs.bind(null, imports);
                     const generatorOutput = generator.output?.bind(null, imports);
-                    this._solvers[iGroup][iParticle] = new dopri.DDE(
+                    this._solvers[iParticle] = new dopri.DDE(
                         generatorRhs,
                         this._rhsVariablesLength,
                         // these are the control params which will be added in a future ticket: mrc-6742
@@ -220,7 +211,7 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
                 } else {
                     const generatorRhs = generator.rhs.bind(null, imports);
                     const generatorOutput = generator.output?.bind(null, imports);
-                    this._solvers[iGroup][iParticle] = new dopri.Dopri(
+                    this._solvers[iParticle] = new dopri.Dopri(
                         generatorRhs,
                         this._rhsVariablesLength,
                         {},
@@ -228,20 +219,15 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
                     );
                 }
             }
-            this._state.setParticle(iGroup, iParticle, arrayState);
+            this._state.setParticle(iParticle, arrayState);
         });
     }
 
     /**
      * @copyDoc SystemInterface.setState
      */
-    public setState(
-        newState: SystemSubState,
-        groupIndices: number[] = [],
-        particleIndices: number[] = [],
-        stateElementIndices: number[] = []
-    ) {
-        this._state.setState(newState, groupIndices, particleIndices, stateElementIndices);
+    public setState(newState: SystemSubState, particleIndices: number[] = [], stateElementIndices: number[] = []) {
+        this._state.setState(newState, particleIndices, stateElementIndices);
     }
 
     /**
@@ -259,22 +245,10 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
             return;
         }
         const nSteps = (time - this._time) / this._dt;
-        this.iterateParticles((iGroup: number, iParticle: number) => {
-            const shared = this._shared[iGroup];
-            const internal = this._internal[iGroup];
-            const solver = this._solvers[iGroup][iParticle];
-            const state = this.runParticle(
-                shared,
-                internal,
-                this._zeroEvery[iGroup],
-                this._state.getParticle(iGroup, iParticle),
-                nSteps,
-                solver,
-                time,
-                iGroup,
-                iParticle
-            );
-            this._state.setParticle(iGroup, iParticle, state);
+        this.iterateParticles((iParticle) => {
+            const solver = this._solvers[iParticle];
+            const state = this.runParticle(this._state.getParticle(iParticle), nSteps, solver, time, iParticle);
+            this._state.setParticle(iParticle, state);
         });
         this._time = time;
     }
@@ -292,46 +266,37 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
             ? stateElementIndices
             : [...Array(this._state.nStateElements).keys()];
 
-        const result = new SystemSimulateResult(
-            this._nGroups,
-            this._nParticles,
-            stateIndicesToReturn.length,
-            times.length
-        );
+        const result = new SystemSimulateResult(this._nParticles, stateIndicesToReturn.length, times.length);
         times.forEach((t, iTime) => {
             this.runToTime(t);
 
-            this.iterateParticles((iGroup: number, iParticle: number) => {
-                const particle = this._state.getParticle(iGroup, iParticle);
+            this.iterateParticles((iParticle) => {
+                const particle = this._state.getParticle(iParticle);
                 const stateValues = stateIndicesToReturn.map((index) => particle.get(index));
-                result.setValuesForTime(iGroup, iParticle, iTime, stateValues);
+                result.setValuesForTime(iParticle, iTime, stateValues);
             });
         });
         return result;
     }
 
     private runParticleWithDt(
-        shared: TShared,
-        internal: TInternal,
-        zeroEvery: ZeroEvery,
         particleState: ParticleState,
         nSteps: number,
         solver: dopri.Dopri | dopri.DDE | null,
-        iGroup: number,
         iParticle: number
     ): number[] {
         let state = particleStateToArray(particleState);
         let stateNext = [...state];
         let time = this._time;
         for (let i = 0; i < nSteps; i++) {
-            zeroEvery.forEach(([frequency, indicesToReset]) => {
+            this._zeroEvery.forEach(([frequency, indicesToReset]) => {
                 if (floatIsDivisibleBy(time, frequency)) {
                     indicesToReset.forEach((idx) => (state[idx] = 0));
                 }
             });
             const nextTime = time + this._dt;
             if (solver) {
-                const history = this._history[iGroup][iParticle];
+                const history = this._history[iParticle];
                 if (this._generatorCfg.hasDelays) {
                     solver.initialise(time, state.slice(0, this._rhsVariablesLength), history);
                 } else {
@@ -340,11 +305,11 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
                 const solution = solver.run(nextTime);
                 state = solution([nextTime])[0];
                 stateNext = [...state];
-                this._history[iGroup][iParticle] = history.concat(solver.getHistory());
+                this._history[iParticle] = history.concat(solver.getHistory());
             }
             const { update } = this._generatorCfg.generator;
             if (update) {
-                update(imports, time, this._dt, state, shared, internal, stateNext, this._random);
+                update(imports, time, this._dt, state, this._params, this._internal, stateNext, this._random);
             }
             time = nextTime;
             const tmp = state;
@@ -366,14 +331,10 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
     }
 
     private runParticle(
-        shared: TShared,
-        internal: TInternal,
-        zeroEvery: ZeroEvery,
         particleState: ParticleState,
         nSteps: number,
         solver: dopri.Dopri | dopri.DDE | null,
         endTime: number,
-        iGroup: number,
         iParticle: number
     ): number[] {
         const { isContinuous, generator } = this._generatorCfg;
@@ -382,67 +343,36 @@ export class System<TShared, TInternal, TData> implements SystemInterface<TData>
         if (noUpdateOrZeroEvery || invalidDt) {
             return this.runParticleWithSolver(particleState, endTime, solver);
         } else {
-            return this.runParticleWithDt(
-                shared,
-                internal,
-                zeroEvery,
-                particleState,
-                nSteps,
-                solver,
-                iGroup,
-                iParticle
-            );
+            return this.runParticleWithDt(particleState, nSteps, solver, iParticle);
         }
     }
 
     /**
-     * Updates shared (parameter) values for all groups in the system.
-     * @param newShared Updated parameter values. The length must match the existing number of groups in the system.
+     * Updates parameter values in the system.
+     * @param newParams Updated parameter values.
      */
-    public updateShared(newShared: TShared[]) {
-        if (newShared.length !== this._shared.length) {
-            throw new DustParameterError(
-                "New shared value must be same length as previous value. " +
-                    `Expected ${this._shared.length} but got ${newShared.length}.`
-            );
-        }
-        for (let i = 0; i < this._shared.length; i++) {
-            this._generatorCfg.generator.updateShared(imports, this._shared[i], newShared[i]);
-        }
+    public updateParams(newParams: TParams) {
+        this._generatorCfg.generator.updateParams(imports, this._params, newParams);
     }
 
-    public compareData(data: TData[] | TData) {
+    public compareData(data: TData) {
         const { generator } = this._generatorCfg;
         if (generator.compareData) {
             const { compareData } = generator;
 
-            // are we sharing data between all groups
-            const isSharedData = !Array.isArray(data) || data.length === 1;
-            let sharedData: TData;
-            if (isSharedData) {
-                sharedData = Array.isArray(data) ? data[0] : data;
-            } else {
-                if (data.length !== this._nGroups) {
-                    throw new RangeError("Expected data to have same length as groups.");
-                }
-            }
-
-            const result = ndarray(new Array(this._nGroups * this._nParticles), [this._nGroups, this._nParticles]);
-            this.iterateParticles((iGroup: number, iParticle: number) => {
-                const iData = isSharedData ? sharedData : data[iGroup];
-                const state = this._state.getParticle(iGroup, iParticle);
-                const shared = this._shared[iGroup];
-                const internal = this._internal[iGroup];
+            const result = ndarray(new Array(this._nParticles), [this._nParticles]);
+            this.iterateParticles((iParticle) => {
+                const state = this._state.getParticle(iParticle);
                 const comparisonValue = compareData(
                     imports,
                     this._time,
                     particleStateToArray(state),
-                    iData,
-                    shared,
-                    internal,
+                    data,
+                    this._params,
+                    this._internal,
                     this._random
                 );
-                result.set(iGroup, iParticle, comparisonValue);
+                result.set(iParticle, comparisonValue);
             });
             return result;
         } else {

--- a/src/SystemSimulateResult.ts
+++ b/src/SystemSimulateResult.ts
@@ -28,7 +28,7 @@ export class SystemSimulateResult {
         this._nStateElements = nStateElements;
         this._nTimes = nTimes;
 
-        // arrange the ndArray with dimensions: group, particle, stateElement * time
+        // arrange the ndArray with dimensions: particle, stateElement * time
         const len = this._nParticles * this._nStateElements * this._nTimes;
         this._resultValues = ndarray(new Array<number>(len).fill(0), [
             this._nParticles,

--- a/src/SystemSimulateResult.ts
+++ b/src/SystemSimulateResult.ts
@@ -8,7 +8,6 @@ import { ArrayState, ParticleState } from "./SystemState.ts";
  * get state values by element index or time index.
  */
 export class SystemSimulateResult {
-    private _nGroups: number;
     private readonly _nParticles: number;
     private readonly _nStateElements: number;
     private readonly _nTimes: number;
@@ -16,26 +15,22 @@ export class SystemSimulateResult {
 
     /**
      *
-     * @param nGroups The number of groups in the {@link SystemInterface}
-     * @param nParticles The number of particles per group
+     * @param nParticles The number of particles
      * @param nStateElements The number of state elements for which this object holds state values
      * @param nTimes The number of times for which this object holds state values
      */
-    constructor(nGroups: number, nParticles: number, nStateElements: number, nTimes: number) {
-        checkIntegerInRange("Number of groups", nGroups, 1);
+    constructor(nParticles: number, nStateElements: number, nTimes: number) {
         checkIntegerInRange("Number of particles", nParticles, 1);
         checkIntegerInRange("Number of state elements", nStateElements, 1);
         checkIntegerInRange("Number of times", nTimes, 1);
 
-        this._nGroups = nGroups;
         this._nParticles = nParticles;
         this._nStateElements = nStateElements;
         this._nTimes = nTimes;
 
         // arrange the ndArray with dimensions: group, particle, stateElement * time
-        const len = this._nGroups * this._nParticles * this._nStateElements * this._nTimes;
+        const len = this._nParticles * this._nStateElements * this._nTimes;
         this._resultValues = ndarray(new Array<number>(len).fill(0), [
-            this._nGroups,
             this._nParticles,
             this._nStateElements,
             this._nTimes
@@ -54,14 +49,13 @@ export class SystemSimulateResult {
      * but may be a a partial array of all elements in the particle, depending on the elements requested in the
      * simulate call.
      *
-     * @param iGroup Index of the group
      * @param iParticle Index of the particle
      * @param iTime Index of the time - NB not time value, but the index in the times parameter provided to
      * {@link SystemInterface#simulate | SystemInterface.simulate}
      */
-    public getValuesForTime(iGroup: number, iParticle: number, iTime: number): ParticleState {
-        this.checkIndexes(iGroup, iParticle, null, iTime);
-        return this._resultValues.pick(iGroup, iParticle, null, iTime);
+    public getValuesForTime(iParticle: number, iTime: number): ParticleState {
+        this.checkIndexes(iParticle, null, iTime);
+        return this._resultValues.pick(iParticle, null, iTime);
     }
 
     /**
@@ -71,13 +65,13 @@ export class SystemSimulateResult {
      * @param stateValues The state values to set, for all values requested in the stateElementIndices parameter
      * provided to {@link SystemInterface#simulate  | SystemInterface.simulate}
      */
-    public setValuesForTime(iGroup: number, iParticle: number, iTime: number, stateValues: number[]) {
-        this.checkIndexes(iGroup, iParticle, null, iTime);
+    public setValuesForTime(iParticle: number, iTime: number, stateValues: number[]) {
+        this.checkIndexes(iParticle, null, iTime);
         if (stateValues.length !== this._nStateElements) {
             throw RangeError(`Expected ${this._nStateElements} state values but got ${stateValues.length}.`);
         }
         for (let i = 0; i < stateValues.length; i++) {
-            this._resultValues.set(iGroup, iParticle, i, iTime, stateValues[i]);
+            this._resultValues.set(iParticle, i, iTime, stateValues[i]);
         }
     }
 
@@ -89,13 +83,12 @@ export class SystemSimulateResult {
      * the index in the stateElementIndices parameter provided to
      * {@link SystemInterface#simulate | SystemInterface.simulate}
      */
-    public getStateElement(iGroup: number, iParticle: number, iStateElement: number): ArrayState {
-        this.checkIndexes(iGroup, iParticle, iStateElement, null);
-        return this._resultValues.pick(iGroup, iParticle, iStateElement, null);
+    public getStateElement(iParticle: number, iStateElement: number): ArrayState {
+        this.checkIndexes(iParticle, iStateElement, null);
+        return this._resultValues.pick(iParticle, iStateElement, null);
     }
 
-    private checkIndexes(iGroup: number, iParticle: number, iStateElement: number | null, iTime: number | null) {
-        checkIntegerInRange("Group index", iGroup, 0, this._nGroups - 1);
+    private checkIndexes(iParticle: number, iStateElement: number | null, iTime: number | null) {
         checkIntegerInRange("Particle index", iParticle, 0, this._nParticles - 1);
         if (iStateElement !== null) {
             checkIntegerInRange("State Element index", iStateElement, 0, this._nStateElements - 1);

--- a/src/SystemState.ts
+++ b/src/SystemState.ts
@@ -29,33 +29,28 @@ export interface ArrayState {
 export type ParticleState = ArrayState;
 
 export type ParticleSubState = number[];
-export type GroupSubState = ParticleSubState[];
 
 /**
  * Type used for full or partial state updates.
  */
-export type SystemSubState = GroupSubState[];
+export type SystemSubState = ParticleSubState[];
 
 /**
- * Class representing the state of a {@link SystemInterface} made up of {@link SystemState.nGroups | nGroups} groups
- * with {@link SystemState.nParticles | nParticles} particles in each group, where each particle contains
- * {@link SystemState.nStateElements | nStateElements} numeric values.
+ * Class representing the state of a {@link SystemInterface} made up of {@link SystemState.nParticles | nParticles}
+ * particles, where each particle contains {@link SystemState.nStateElements | nStateElements} numeric values.
  */
 export class SystemState {
     private _state: ndarray.NdArray;
     private _stateNext: ndarray.NdArray; // a working area for building next state value before swapping into _state
-    private readonly _nGroups: number;
     private readonly _nParticles: number;
     private readonly _nStateElements: number;
 
     /**
      *
-     * @param nGroups The number of groups in the state where each group shares model parameter values
-     * @param nParticles The number of particles in each group
+     * @param nParticles The number of particles
      * @param nStateElements The number of numeric state values in each particle
      */
-    constructor(nGroups: number, nParticles: number, nStateElements: number) {
-        this._nGroups = nGroups;
+    constructor(nParticles: number, nStateElements: number) {
         this._nParticles = nParticles;
         this._nStateElements = nStateElements;
         this._state = this.newState();
@@ -63,20 +58,13 @@ export class SystemState {
     }
 
     private newState() {
-        // arrange the ndArray with dimensions: group, particle, stateElement
-        const len = this._nGroups * this._nParticles * this._nStateElements;
-        return ndarray(new Array<number>(len).fill(0), [this._nGroups, this._nParticles, this._nStateElements]);
+        // arrange the ndArray with dimensions: particle, stateElement
+        const len = this._nParticles * this._nStateElements;
+        return ndarray(new Array<number>(len).fill(0), [this._nParticles, this._nStateElements]);
     }
 
     /**
-     * The number of groups in the system
-     */
-    public get nGroups(): number {
-        return this._nGroups;
-    }
-
-    /**
-     * The number of particles per group in the system
+     * The number of particles in the system
      */
     public get nParticles(): number {
         return this._nParticles;
@@ -90,64 +78,51 @@ export class SystemState {
     }
 
     /**
-     * Returns a slice of the underlying state which is a view of a particular group and particle
-     * @param iGroup The group index to get
+     * Returns a slice of the underlying state which is a view of a particular particle
      * @param iParticle The particle index to get
      */
-    public getParticle(iGroup: number, iParticle: number): ArrayState {
-        this.checkIndexes(iGroup, iParticle);
-        return this._state.pick(iGroup, iParticle, null);
+    public getParticle(iParticle: number): ArrayState {
+        this.checkIndex(iParticle);
+        return this._state.pick(iParticle, null);
     }
 
     /**
      * Updates the underlying state with the given values for a particular particle
-     * @param iGroup The group index to set values for
      * @param iParticle The particle index to set values for
      * @param values The values to set in the underlying state
      */
-    public setParticle(iGroup: number, iParticle: number, values: number[]): void {
-        this.checkIndexes(iGroup, iParticle);
+    public setParticle(iParticle: number, values: number[]): void {
+        this.checkIndex(iParticle);
         if (values.length !== this._nStateElements) {
             throw new RangeError(`Particle state array must be of length ${this._nStateElements}.`);
         }
         for (let i = 0; i < values.length; i++) {
-            this._state.set(iGroup, iParticle, i, values[i]);
+            this._state.set(iParticle, i, values[i]);
         }
     }
 
-    private checkIndexes(iGroup: number, iParticle: number) {
-        checkIntegerInRange("Group index", iGroup, 0, this._nGroups - 1);
+    private checkIndex(iParticle: number) {
         checkIntegerInRange("Particle index", iParticle, 0, this._nParticles - 1);
     }
 
     /**
-     * Apply a reordering to the particles in every group according to a reordering parameter which defines
-     * a new order for each group.
-     * @param reordering {@link https://github.com/scijs/ndarray | NdArray } whose first dimension defines group index
-     * and whose second dimension defines a new order of particles for each group. For example, if this state has three
-     * particles per group, a reordering of `[2, 0, 1]` for any group would imply that its current third particle should
-     * be reordered to the first position, its current first particle to the second position, and its current second
-     * particle to the third position. Reordering can also perform filtering and duplication i.e. indexes between 0
-     * and {@link nParticles} - 1 may be repeated or omitted in the reordering.
+     * Apply a reordering to every particle according to a reordering parameter which defines a new order.
+     * @param reordering {@link https://github.com/scijs/ndarray | NdArray } whose first dimension defines a new order
+     * of particles. For example, if this state has three particles, a reordering of `[2, 0, 1]` would imply that its
+     * current third particle should be reordered to the first position, its current first particle to the second
+     * position, and its current second particle to the third position. Reordering can also perform filtering and
+     * duplication i.e. indexes between 0 and {@link nParticles} - 1 may be repeated or omitted in the reordering.
      */
     public reorder(reordering: ndarray.NdArray) {
         const shape = reordering.shape;
-        if (shape.length !== 2 || shape[0] !== this._nGroups || shape[1] !== this._nParticles) {
+        if (shape.length !== 1 || shape[0] !== this._nParticles) {
             throw new DustParameterError(
-                "Unexpected reordering shape. " +
-                    `Expected [${this._nGroups},${this._nParticles}] but got ${JSON.stringify(shape)}.`
+                "Unexpected reordering shape. " + `Expected [${this._nParticles}] but got ${JSON.stringify(shape)}.`
             );
         }
         // Check that each reordering contains expected values
-        for (let iGroup = 0; iGroup < this._nGroups; iGroup++) {
-            for (let newParticleIndex = 0; newParticleIndex < this._nParticles; newParticleIndex++) {
-                checkIntegerInRange(
-                    "Reordering index",
-                    reordering.get(iGroup, newParticleIndex),
-                    0,
-                    this._nParticles - 1
-                );
-            }
+        for (let newParticleIndex = 0; newParticleIndex < this._nParticles; newParticleIndex++) {
+            checkIntegerInRange("Reordering index", reordering.get(newParticleIndex), 0, this._nParticles - 1);
         }
 
         this.reorderNoCheck(reordering);
@@ -155,13 +130,11 @@ export class SystemState {
 
     // We'll use this eventually when we want to generate our own indexes internal to the package
     private reorderNoCheck(reordering: ndarray.NdArray) {
-        for (let iGroup = 0; iGroup < this._nGroups; iGroup++) {
-            for (let newParticleIndex = 0; newParticleIndex < this._nParticles; newParticleIndex++) {
-                const oldParticleIndex = reordering.get(iGroup, newParticleIndex);
-                const particleValues = this.getParticle(iGroup, oldParticleIndex);
-                for (let iStateElement = 0; iStateElement < this._nStateElements; iStateElement++) {
-                    this._stateNext.set(iGroup, newParticleIndex, iStateElement, particleValues.get(iStateElement));
-                }
+        for (let newParticleIndex = 0; newParticleIndex < this._nParticles; newParticleIndex++) {
+            const oldParticleIndex = reordering.get(newParticleIndex);
+            const particleValues = this.getParticle(oldParticleIndex);
+            for (let iStateElement = 0; iStateElement < this._nStateElements; iStateElement++) {
+                this._stateNext.set(newParticleIndex, iStateElement, particleValues.get(iStateElement));
             }
         }
 
@@ -171,20 +144,14 @@ export class SystemState {
     /**
      * @copyDoc SystemInterface.setState
      */
-    public setState(
-        newState: SystemSubState,
-        groupIndices: number[] = [],
-        particleIndices: number[] = [],
-        stateElementIndices: number[] = []
-    ) {
+    public setState(newState: SystemSubState, particleIndices: number[] = [], stateElementIndices: number[] = []) {
         // Check that the dimensions of new state actually match size of the indices arrays
         // provided (or the relevant dimension of the whole state if not)
         const expectedNewStateLengths = [
-            groupIndices.length || this._nGroups,
             particleIndices.length || this._nParticles,
             stateElementIndices.length || this._nStateElements
         ];
-        const expectedNewStateNames = ["newState Groups", "newState Particles", "newState State Elements"];
+        const expectedNewStateNames = ["newState Particles", "newState State Elements"];
         checkNestedArrayLengthsMatch(newState, expectedNewStateLengths, expectedNewStateNames);
 
         const iterateIndices = (
@@ -207,17 +174,15 @@ export class SystemState {
             }
         };
 
-        iterateIndices("Group index", groupIndices, this._nGroups, (g: number, ig: number) => {
-            iterateIndices("Particle index", particleIndices, this._nParticles, (p: number, ip: number) => {
-                iterateIndices(
-                    "State Element index",
-                    stateElementIndices,
-                    this._nStateElements,
-                    (v: number, iv: number) => {
-                        this._state.set(g, p, v, newState[ig][ip][iv]);
-                    }
-                );
-            });
+        iterateIndices("Particle index", particleIndices, this._nParticles, (p: number, ip: number) => {
+            iterateIndices(
+                "State Element index",
+                stateElementIndices,
+                this._nStateElements,
+                (v: number, iv: number) => {
+                    this._state.set(p, v, newState[ip][iv]);
+                }
+            );
         });
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,5 @@ export { Packer } from "./Packer";
 export type { PackerOptions, PackerShape, UnpackResult } from "./Packer";
 export { SystemState } from "./SystemState.ts";
 export { SystemSimulateResult } from "./SystemSimulateResult.ts";
-export type { ArrayState, SystemSubState, GroupSubState, ParticleSubState } from "./SystemState.ts";
+export type { ArrayState, SystemSubState, ParticleSubState } from "./SystemState.ts";
 export type { ZeroEvery, Frequency, StateIndexForZero } from "./zero.ts";

--- a/src/interfaces/System.ts
+++ b/src/interfaces/System.ts
@@ -25,19 +25,12 @@ export interface SystemInterface<TData> {
      * Sets new values in the system state
      * @param newState The new state values for all or part of the state. If partial state, the shape must match the
      * values provided in the indices parameters
-     * @param groupIndices The group indices, in order, which the first dimension of newState are setting values for.
-     * If empty, this means newState provides values for all groups.
      * @param particleIndices The particle indices, in order, which the second dimension of newState are setting values
      * for. If empty, this means newState provides values for all particles.
      * @param stateElementIndices The state element indices, in order, which the second dimension of newState are
      * setting values for. If empty, this means newState provides values for all state elements.
      */
-    setState(
-        newState: SystemSubState,
-        groupIndices: number[],
-        particleIndices: number[],
-        stateElementIndices: number[]
-    ): void;
+    setState(newState: SystemSubState, particleIndices: number[], stateElementIndices: number[]): void;
 
     /**
      * Runs the system from its current time to the given time, causing its state to be updated
@@ -58,7 +51,7 @@ export interface SystemInterface<TData> {
     /**
      * Compares the state of all particles in the syatem with observed data, and returns an
      * {@link https://github.com/scijs/ndarray |NdArray } of log likelihoods
-     * of each particle state given the data, where the NdArray has shape [nGroups, nParticles]
+     * of each particle state given the data, where the NdArray has shape [nParticles]
      * @param data Observed data to compare against system state
      */
     compareData(data: TData | TData[]): NdArray;

--- a/src/interfaces/generators/BaseGenerator.ts
+++ b/src/interfaces/generators/BaseGenerator.ts
@@ -21,7 +21,7 @@ export interface BaseGenerator<TParams, TInternal, TData> {
      *
      * @param imports Object containing useful classes/utilities from this package the class may need
      * @param time The current time at which to initialise particle state
-     * @param params The shared parameter values used by the particle
+     * @param params The parameter values used by the particle
      * @param internal The internal state used by the particle
      * @param stateNext The array of values which should be updated by the generator with initial particle state values
      * @param random A random number generator which may be used by the generator to initialise values

--- a/src/interfaces/generators/BaseGenerator.ts
+++ b/src/interfaces/generators/BaseGenerator.ts
@@ -38,7 +38,7 @@ export interface BaseGenerator<TParams, TInternal, TData> {
     /**
      * Generates initial internal state for a given parameter state
      * @param imports Object containing useful classes/utilities from this package the class may need
-     * @param params The shared parameter values used by the particle
+     * @param params The parameter values used by the particle
      */
     internal(imports: Imports, params: TParams): TInternal;
 

--- a/src/interfaces/generators/BaseGenerator.ts
+++ b/src/interfaces/generators/BaseGenerator.ts
@@ -7,64 +7,64 @@ import { Imports } from "./Imports.ts";
  * Interface defining the functionality of a general odin model. Generators are stateless and are always provided
  * with all state and other parameters required to update the particle in each method.
  *
- * @typeParam TShared Values which are shared between all particles in a group and are not mutated by them -
- * the model parameter values for that group
+ * @typeParam TParams Values which are shared between all particles are not mutated by them - i.e.
+ * the model parameter values
  *
  * @typeParam TInternal Internal state values which can be mutated by generators, used to improve efficiency of the
  * system by e.g. caching calculation results for use by other particles.
  *
  * @typeParam TData Type of each data point which will be compared with system state.
  */
-export interface BaseGenerator<TShared, TInternal, TData> {
+export interface BaseGenerator<TParams, TInternal, TData> {
     /**
      * Sets the initial state of a particle.
      *
      * @param imports Object containing useful classes/utilities from this package the class may need
      * @param time The current time at which to initialise particle state
-     * @param shared The shared parameter values used by the particle's group
-     * @param internal The internal state used by the particle's group
+     * @param params The shared parameter values used by the particle
+     * @param internal The internal state used by the particle
      * @param stateNext The array of values which should be updated by the generator with initial particle state values
      * @param random A random number generator which may be used by the generator to initialise values
      */
     initial(
         imports: Imports,
         time: number,
-        shared: TShared,
+        params: TParams,
         internal: TInternal,
         stateNext: number[],
         random: Random
     ): void;
 
     /**
-     * Generates initial internal state for a given shared state
+     * Generates initial internal state for a given parameter state
      * @param imports Object containing useful classes/utilities from this package the class may need
-     * @param shared The shared state to generate initial internal state for
+     * @param params The shared parameter values used by the particle
      */
-    internal(imports: Imports, shared: TShared): TInternal;
+    internal(imports: Imports, params: TParams): TInternal;
 
     /**
-     * Gets a {@link Packer} which can pack shared state values into a one dimensional array
+     * Gets a {@link Packer} which can pack params state values into a one dimensional array
      * @param imports Object containing useful classes/utilities from this package the class may need
-     * @param shared The shared state which the result should pack
+     * @param params The shared parameter values used by the particle
      */
-    packingState(imports: Imports, shared: TShared): Packer;
+    packingState(imports: Imports, params: TParams): Packer;
 
     /**
      * Updates values in a system parameter set from a new parameter set. A generator may
      * do custom updating of some values.
      * @param imports Object containing useful classes/utilities from this package the class may need
-     * @param shared The shared parameter set to update
-     * @param newShared The parameter set to update from
+     * @param params The parameter set to update
+     * @param newParams The parameter set to update from
      */
-    updateShared(imports: Imports, shared: TShared, newShared: TShared): void;
+    updateParams(imports: Imports, params: TParams, newParams: TParams): void;
 
     /**
      * Gets a {@link ZeroEvery} vector used to reset certain indices of state to 0 at a
      * given frequency
      * @param imports Object containing useful classes/utilities from this package the class may need
-     * @param shared The shared parameter set to update
+     * @param params The parameter set to update
      */
-    getZeroEvery?(imports: Imports, shared: TShared): ZeroEvery;
+    getZeroEvery?(imports: Imports, params: TParams): ZeroEvery;
 
     /**
      * Compares the state of a particle with a data point, and returns the log likelihood of the state given the data.
@@ -72,8 +72,8 @@ export interface BaseGenerator<TShared, TInternal, TData> {
      * @param imports Object containing useful classes/utilities from this package the class may need
      * @param time The new time to which the particle state should be updated.
      * @param state The current state of the particle
-     * @param shared The shared parameter values used by the particle's group
-     * @param internal The internal state used by the particle's group
+     * @param params The parameter values used by the particle
+     * @param internal The internal state used by the particle
      * @param random A random number generator which may be used by the generator to update values
      * @param data The data point
      */
@@ -82,7 +82,7 @@ export interface BaseGenerator<TShared, TInternal, TData> {
         time: number,
         state: number[],
         data: TData,
-        shared: TShared,
+        params: TParams,
         internal: TInternal,
         random: Random
     ): number;

--- a/src/interfaces/generators/BaseGenerator.ts
+++ b/src/interfaces/generators/BaseGenerator.ts
@@ -45,7 +45,7 @@ export interface BaseGenerator<TParams, TInternal, TData> {
     /**
      * Gets a {@link Packer} which can pack params state values into a one dimensional array
      * @param imports Object containing useful classes/utilities from this package the class may need
-     * @param params The shared parameter values used by the particle
+     * @param params The parameter values used by the particle
      */
     packingState(imports: Imports, params: TParams): Packer;
 

--- a/src/interfaces/generators/ContinuousGenerator.ts
+++ b/src/interfaces/generators/ContinuousGenerator.ts
@@ -23,7 +23,7 @@ export type FullSolution = (t: number[]) => number[][];
  *
  * @copyDoc BaseGenerator
  */
-export interface ContinuousGeneratorBase<TShared, TInternal, TData> extends BaseGenerator<TShared, TInternal, TData> {
+export interface ContinuousGeneratorBase<TParams, TInternal, TData> extends BaseGenerator<TParams, TInternal, TData> {
     /**
      * @copyDoc DiscreteGenerator.update
      */
@@ -32,7 +32,7 @@ export interface ContinuousGeneratorBase<TShared, TInternal, TData> extends Base
         time: number,
         dt: number,
         state: number[],
-        shared: TShared,
+        params: TParams,
         internal: TInternal,
         stateNext: number[],
         random: Random
@@ -45,8 +45,8 @@ export interface ContinuousGeneratorBase<TShared, TInternal, TData> extends Base
  *
  * @copyDoc BaseGenerator
  */
-export interface ContinuousGeneratorODE<TShared, TInternal, TData>
-    extends ContinuousGeneratorBase<TShared, TInternal, TData> {
+export interface ContinuousGeneratorODE<TParams, TInternal, TData>
+    extends ContinuousGeneratorBase<TParams, TInternal, TData> {
     /**
      * Compute the derivatives
      *
@@ -78,8 +78,8 @@ export interface ContinuousGeneratorODE<TShared, TInternal, TData>
  *
  * @copyDoc BaseGenerator
  */
-export interface ContinuousGeneratorDDE<TShared, TInternal, TData>
-    extends ContinuousGeneratorBase<TShared, TInternal, TData> {
+export interface ContinuousGeneratorDDE<TParams, TInternal, TData>
+    extends ContinuousGeneratorBase<TParams, TInternal, TData> {
     /**
      * @copyDoc ContinuousGeneratorODE.rhs
      *

--- a/src/interfaces/generators/DiscreteGenerator.ts
+++ b/src/interfaces/generators/DiscreteGenerator.ts
@@ -8,7 +8,7 @@ import { Imports } from "./Imports.ts";
  *
  * @copyDoc BaseGenerator
  */
-export interface DiscreteGenerator<TShared, TInternal, TData> extends BaseGenerator<TShared, TInternal, TData> {
+export interface DiscreteGenerator<TParams, TInternal, TData> extends BaseGenerator<TParams, TInternal, TData> {
     /**
      * Updates the state of a particle from its previous state.
      *
@@ -16,8 +16,8 @@ export interface DiscreteGenerator<TShared, TInternal, TData> extends BaseGenera
      * @param time The new time to which the particle state should be updated.
      * @param dt The time step from the current time to the new time
      * @param state The current state of the particle
-     * @param shared The shared parameter values used by the particle's group
-     * @param internal The internal state used by the particle's group
+     * @param params The parameter values used by the particle
+     * @param internal The internal state used by the particle
      * @param stateNext The array of values which should be updated by the generator with new particle state values
      * @param random A random number generator which may be used by the generator to update values
      */
@@ -26,7 +26,7 @@ export interface DiscreteGenerator<TShared, TInternal, TData> extends BaseGenera
         time: number,
         dt: number,
         state: number[],
-        shared: TShared,
+        params: TParams,
         internal: TInternal,
         stateNext: number[],
         random: Random

--- a/src/interfaces/generators/Generator.ts
+++ b/src/interfaces/generators/Generator.ts
@@ -2,19 +2,19 @@ import { ContinuousGeneratorDDE, ContinuousGeneratorODE } from "./ContinuousGene
 import { DiscreteGenerator } from "./DiscreteGenerator";
 
 // discriminated union so type system can work out what type of generator we are using
-export type GeneratorConfig<TShared, TInternal, TData> =
+export type GeneratorConfig<TParams, TInternal, TData> =
     | {
-          generator: DiscreteGenerator<TShared, TInternal, TData>;
+          generator: DiscreteGenerator<TParams, TInternal, TData>;
           isContinuous: false;
           hasDelays: false;
       }
     | {
-          generator: ContinuousGeneratorODE<TShared, TInternal, TData>;
+          generator: ContinuousGeneratorODE<TParams, TInternal, TData>;
           isContinuous: true;
           hasDelays: false;
       }
     | {
-          generator: ContinuousGeneratorDDE<TShared, TInternal, TData>;
+          generator: ContinuousGeneratorDDE<TParams, TInternal, TData>;
           isContinuous: true;
           hasDelays: true;
       };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export const checkNestedArrayLengthsMatch = (
     }
 };
 
-// Convert an arrays into an NdArray
+// Convert an array into an NdArray
 export const ndArrayFrom = (source: number[]): ndarray.NdArray => {
     if (source.length === 0) {
         throw new DustParameterError("Cannot convert from empty source");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,20 +81,11 @@ export const checkNestedArrayLengthsMatch = (
 };
 
 // Convert an array of arrays into an NdArray
-export const ndArrayFrom = (source: number[][]): ndarray.NdArray => {
+export const ndArrayFrom = (source: number[]): ndarray.NdArray => {
     if (source.length === 0) {
         throw new DustParameterError("Cannot convert from empty source");
     }
-    const expectedLength = source[0].length;
-    if (source.some((arr) => arr.length !== expectedLength)) {
-        throw new DustParameterError("Source arrays must all be the same length");
-    }
-
-    const values = source.reduce((acc, current) => {
-        acc.push(...current);
-        return acc;
-    }, [] as number[]);
-    return ndarray(values, [source.length, expectedLength]);
+    return ndarray(source, [source.length]);
 };
 
 export const getRangeFromZero = (count: number) => [...Array(count).keys()];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export const checkNestedArrayLengthsMatch = (
     }
 };
 
-// Convert an array of arrays into an NdArray
+// Convert an arrays into an NdArray
 export const ndArrayFrom = (source: number[]): ndarray.NdArray => {
     if (source.length === 0) {
         throw new DustParameterError("Cannot convert from empty source");

--- a/tests/ComparableSystem.test.ts
+++ b/tests/ComparableSystem.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect, vi, Mocked, MockInstance } from "vitest";
 import { poissonLogDensity } from "../src/density.ts";
-import { discreteSIR, SIRData, SIRShared } from "./examples/discreteSIR.ts";
+import { discreteSIR, SIRData, SIRParams } from "./examples/discreteSIR.ts";
 import { Random } from "@reside-ic/random";
-import { expectedGroup1Initial, expectedGroup2Initial, sirShared } from "./examples/SIRTestHelpers.ts";
+import { expectedInitial, sirParams } from "./examples/SIRTestHelpers.ts";
 import ndarray from "ndarray";
 import { System } from "../src/System.ts";
 import { ABState, zeroTwice } from "./examples/zeroTwice.ts";
@@ -11,9 +11,9 @@ import { imports } from "../src/interfaces/generators/Imports.ts";
 const generator = discreteSIR;
 
 const createSystem = (random?: Random) =>
-    System.createDiscrete<SIRShared, null, SIRData>(
+    System.createDiscrete<SIRParams, null, SIRData>(
         generator,
-        sirShared,
+        sirParams,
         5, // time
         0.5, // dt
         3, // nParticles
@@ -25,28 +25,20 @@ describe("ComparableDiscreteSystem", () => {
     test("can compare data", () => {
         const genCompareDataSpy = vi.spyOn(generator, "compareData") as MockInstance;
         const sys = createSystem();
-        sys.setStateInitial(); // compare data with initial state where grp1 I = 1, and grp2 I = 2
-        const data = [{ prevalence: 2 }, { prevalence: 3 }];
+        sys.setStateInitial(); // compare data with initial state
+        const data = { prevalence: 2 };
         const result = sys.compareData(data);
-        expect(result.shape).toStrictEqual([2, 3]);
-        const expectedGrp1Value = poissonLogDensity(2, 1);
-        expect(result.get(0, 0)).toBe(expectedGrp1Value);
-        expect(result.get(0, 1)).toBe(expectedGrp1Value);
-        expect(result.get(0, 2)).toBe(expectedGrp1Value);
-        const expectedGrp2Value = poissonLogDensity(3, 2);
-        expect(result.get(1, 0)).toBe(expectedGrp2Value);
-        expect(result.get(1, 1)).toBe(expectedGrp2Value);
-        expect(result.get(1, 2)).toBe(expectedGrp2Value);
+        expect(result.shape).toStrictEqual([3]);
+        const expectedValue = poissonLogDensity(2, 1);
+        expect(result.get(0)).toBe(expectedValue);
+        expect(result.get(1)).toBe(expectedValue);
+        expect(result.get(2)).toBe(expectedValue);
 
-        expect(genCompareDataSpy).toHaveBeenCalledTimes(6);
-        const expectedGrp1Params = [imports, 5, expectedGroup1Initial, data[0], sirShared[0], null, sys["_random"]];
-        expect(genCompareDataSpy.mock.calls[0]).toStrictEqual(expectedGrp1Params);
-        expect(genCompareDataSpy.mock.calls[1]).toStrictEqual(expectedGrp1Params);
-        expect(genCompareDataSpy.mock.calls[2]).toStrictEqual(expectedGrp1Params);
-        const expectedGrp2Params = [imports, 5, expectedGroup2Initial, data[1], sirShared[1], null, sys["_random"]];
-        expect(genCompareDataSpy.mock.calls[3]).toStrictEqual(expectedGrp2Params);
-        expect(genCompareDataSpy.mock.calls[4]).toStrictEqual(expectedGrp2Params);
-        expect(genCompareDataSpy.mock.calls[5]).toStrictEqual(expectedGrp2Params);
+        expect(genCompareDataSpy).toHaveBeenCalledTimes(3);
+        const expectedParams = [imports, 5, expectedInitial, data, sirParams, null, sys["_random"]];
+        expect(genCompareDataSpy.mock.calls[0]).toStrictEqual(expectedParams);
+        expect(genCompareDataSpy.mock.calls[1]).toStrictEqual(expectedParams);
+        expect(genCompareDataSpy.mock.calls[2]).toStrictEqual(expectedParams);
     });
 
     const expectSharedDataResult = (
@@ -55,34 +47,17 @@ describe("ComparableDiscreteSystem", () => {
         genCompareDataSpy: Mocked<any>,
         random: Random
     ) => {
-        const expectedGrp1Value = poissonLogDensity(2, 1);
-        expect(result.get(0, 0)).toBe(expectedGrp1Value);
-        expect(result.get(0, 1)).toBe(expectedGrp1Value);
-        expect(result.get(0, 2)).toBe(expectedGrp1Value);
-        const expectedGrp2Value = poissonLogDensity(2, 2);
-        expect(result.get(1, 0)).toBe(expectedGrp2Value);
-        expect(result.get(1, 1)).toBe(expectedGrp2Value);
-        expect(result.get(1, 2)).toBe(expectedGrp2Value);
+        const expectedValue = poissonLogDensity(2, 1);
+        expect(result.get(0)).toBe(expectedValue);
+        expect(result.get(1)).toBe(expectedValue);
+        expect(result.get(2)).toBe(expectedValue);
 
-        expect(genCompareDataSpy).toHaveBeenCalledTimes(6);
-        const expectedGrp1Params = [imports, 5, expectedGroup1Initial, data, sirShared[0], null, random];
-        expect(genCompareDataSpy.mock.calls[0]).toStrictEqual(expectedGrp1Params);
-        expect(genCompareDataSpy.mock.calls[1]).toStrictEqual(expectedGrp1Params);
-        expect(genCompareDataSpy.mock.calls[2]).toStrictEqual(expectedGrp1Params);
-        const expectedGrp2Params = [imports, 5, expectedGroup2Initial, data, sirShared[1], null, random];
-        expect(genCompareDataSpy.mock.calls[3]).toStrictEqual(expectedGrp2Params);
-        expect(genCompareDataSpy.mock.calls[4]).toStrictEqual(expectedGrp2Params);
-        expect(genCompareDataSpy.mock.calls[5]).toStrictEqual(expectedGrp2Params);
+        expect(genCompareDataSpy).toHaveBeenCalledTimes(3);
+        const expectedParams = [imports, 5, expectedInitial, data, sirParams, null, random];
+        expect(genCompareDataSpy.mock.calls[0]).toStrictEqual(expectedParams);
+        expect(genCompareDataSpy.mock.calls[1]).toStrictEqual(expectedParams);
+        expect(genCompareDataSpy.mock.calls[2]).toStrictEqual(expectedParams);
     };
-
-    test("can compare with shared data - single item array", () => {
-        const genCompareDataSpy = vi.spyOn(generator, "compareData");
-        const sys = createSystem();
-        sys.setStateInitial();
-        const data = [{ prevalence: 2 }];
-        const result = sys.compareData(data);
-        expectSharedDataResult(result, data[0], genCompareDataSpy, sys["_random"]);
-    });
 
     test("can compare with shared data - object", () => {
         const genCompareDataSpy = vi.spyOn(generator, "compareData");
@@ -93,23 +68,16 @@ describe("ComparableDiscreteSystem", () => {
         expectSharedDataResult(result, data, genCompareDataSpy, sys["_random"]);
     });
 
-    test("compareData throws error if data is unexpected length", () => {
-        const sys = createSystem();
-        sys.setStateInitial();
-        const data = [{ prevalence: 1 }, { prevalence: 2 }, { prevalence: 3 }];
-        expect(() => sys.compareData(data)).toThrowError("Expected data to have same length as groups.");
-    });
-
     test("compareData throws error generator doesn't specify a compareData Function", () => {
         const sys = System.createDiscrete<ABState, null>(
             zeroTwice,
-            [{ a: 5, b: 10 }],
+            { a: 5, b: 10 },
             5, // time
             0.5, // dt
             3, // nParticles
             undefined
         );
         sys.setStateInitial();
-        expect(() => sys.compareData([])).toThrowError("Generator does not specify a compareData function");
+        expect(() => sys.compareData(null)).toThrowError("Generator does not specify a compareData function");
     });
 });

--- a/tests/ContinuousSystem.test.ts
+++ b/tests/ContinuousSystem.test.ts
@@ -1,23 +1,23 @@
 import { describe, test, expect, vi, afterEach } from "vitest";
 import { System } from "../src/System.ts";
-import { constantGrad, ConstantGradShared } from "./examples/constantGrad.ts";
-import { constantGradNoUpdate, ConstantGradNoUpdateShared } from "./examples/constantGradNoUpdate.ts";
-import { constantGradDelay, ConstantGradDelayShared } from "./examples/constantGradDelay.ts";
+import { constantGrad, ConstantGradParams } from "./examples/constantGrad.ts";
+import { constantGradNoUpdate, ConstantGradNoUpdateParams } from "./examples/constantGradNoUpdate.ts";
+import { constantGradDelay, ConstantGradDelayParams } from "./examples/constantGradDelay.ts";
 
-const createSystem = (shared: ConstantGradShared, dt = 0.001) =>
-    System.createODE<ConstantGradShared, null>(
+const createSystem = (params: ConstantGradParams, dt = 0.001) =>
+    System.createODE<ConstantGradParams, null>(
         constantGrad,
-        [shared],
+        params,
         5, // time
         dt, // dt
         1, // nParticles
         1 // nRhsVariables
     );
 
-const createSystemNoUpdate = (shared: ConstantGradNoUpdateShared) =>
-    System.createODE<ConstantGradNoUpdateShared, null>(
+const createSystemNoUpdate = (params: ConstantGradNoUpdateParams) =>
+    System.createODE<ConstantGradNoUpdateParams, null>(
         constantGradNoUpdate,
-        [shared],
+        params,
         5, // time
         0.001, // dt
         1, // nParticles
@@ -90,10 +90,10 @@ describe("ContinuousSystem", () => {
     });
 
     test("Can initialise and run to time using constantGradDelay generator", () => {
-        const shared = { m: 1, x: 1, c: 1, y: 1, yDelay1: 1 };
-        const sys = System.createDDE<ConstantGradDelayShared, null>(
+        const params = { m: 1, x: 1, c: 1, y: 1, yDelay1: 1 };
+        const sys = System.createDDE<ConstantGradDelayParams, null>(
             constantGradDelay,
-            [shared],
+            params,
             5, // time
             0.001, // dt
             1, // nParticles

--- a/tests/System.test.ts
+++ b/tests/System.test.ts
@@ -1,19 +1,19 @@
 import { describe, test, expect, vi, afterEach } from "vitest";
 import { discreteSIR, SIRData } from "./examples/discreteSIR.ts";
-import { discreteWalk, WalkShared } from "./examples/discreteWalk.ts";
+import { discreteWalk, WalkParams } from "./examples/discreteWalk.ts";
 import { System } from "../src/System.ts";
 import { arrayStateToArray } from "../src/utils.ts";
-import { SIRShared } from "./examples/discreteSIR.ts";
+import { SIRParams } from "./examples/discreteSIR.ts";
 import { Random, RngStateBuiltin, RngStateObserved } from "@reside-ic/random";
-import { expectedGroup1Initial, expectedGroup2Initial, sirShared } from "./examples/SIRTestHelpers.ts";
+import { expectedInitial, sirParams } from "./examples/SIRTestHelpers.ts";
 import { imports } from "../src/interfaces/generators/Imports.ts";
 
 const generator = discreteSIR;
 
 const createSystem = (random?: Random) =>
-    System.createDiscrete<SIRShared, null, SIRData>(
+    System.createDiscrete<SIRParams, null, SIRData>(
         generator,
-        sirShared,
+        sirParams,
         5, // time
         0.5, // dt
         3, // nParticles
@@ -36,26 +36,24 @@ describe("DiscreteSystem", () => {
         expect(sys["_time"]).toBe(5);
         expect(sys["_dt"]).toBe(0.5);
         expect(sys["_nParticles"]).toBe(3);
-        expect(sys["_nGroups"]).toBe(2);
 
         const packer = sys["_statePacker"];
         expect(packer.length).toBe(5);
 
         const state = sys["_state"];
-        expect(state["_nGroups"]).toBe(2);
         expect(state["_nParticles"]).toBe(3);
         expect(state["_nStateElements"]).toBe(5);
 
-        expect(sys["_shared"]).toBe(sirShared);
-        expect(sys["_internal"]).toStrictEqual([null, null]);
+        expect(sys["_params"]).toBe(sirParams);
+        expect(sys["_internal"]).toStrictEqual(null);
 
         expect(sys["_random"]).toBe(random);
     });
 
     test("defaults to built in random", () => {
-        const sys = System.createDiscrete<SIRShared, null, SIRData>(
+        const sys = System.createDiscrete<SIRParams, null, SIRData>(
             generator,
-            sirShared,
+            sirParams,
             5, // time
             0.5, // dt
             3 // nParticles
@@ -66,9 +64,9 @@ describe("DiscreteSystem", () => {
 
     test("constructor throws error if nParticles is invalid", () => {
         expect(() =>
-            System.createDiscrete<SIRShared, null, SIRData>(
+            System.createDiscrete<SIRParams, null, SIRData>(
                 generator,
-                sirShared,
+                sirParams,
                 5, // time
                 0.5, // dt
                 -3 // nParticles
@@ -76,9 +74,9 @@ describe("DiscreteSystem", () => {
         ).toThrowError("Number of particles should be an integer greater than or equal to 1, but is -3.");
 
         expect(() =>
-            System.createDiscrete<SIRShared, null, SIRData>(
+            System.createDiscrete<SIRParams, null, SIRData>(
                 generator,
-                sirShared,
+                sirParams,
                 5, // time
                 0.5, // dt
                 3.1 // nParticles
@@ -88,9 +86,9 @@ describe("DiscreteSystem", () => {
 
     test("throws expected error dt <= 0 or dt is Infinity", () => {
         expect(() =>
-            System.createDiscrete<SIRShared, null, SIRData>(
+            System.createDiscrete<SIRParams, null, SIRData>(
                 generator,
-                sirShared,
+                sirParams,
                 5, // time
                 -1, // dt
                 3 // nParticles
@@ -98,9 +96,9 @@ describe("DiscreteSystem", () => {
         ).toThrowError("dt provided, -1, must be positive and finite");
 
         expect(() =>
-            System.createDiscrete<SIRShared, null, SIRData>(
+            System.createDiscrete<SIRParams, null, SIRData>(
                 generator,
-                sirShared,
+                sirParams,
                 5, // time
                 Infinity, // dt
                 3 // nParticles
@@ -108,15 +106,10 @@ describe("DiscreteSystem", () => {
         ).toThrowError("dt provided, Infinity, must be positive and finite");
     });
 
-    const expectParticleGroupState = (
-        sys: System<any, any, any>,
-        iGroup: number,
-        nParticles: number,
-        expectedValues: number[]
-    ) => {
+    const expectParticleState = (sys: System<any, any, any>, nParticles: number, expectedValues: number[]) => {
         const state = sys.state;
         for (let i = 0; i < nParticles; i++) {
-            expect(arrayStateToArray(state.getParticle(iGroup, i))).toStrictEqual(expectedValues);
+            expect(arrayStateToArray(state.getParticle(i))).toStrictEqual(expectedValues);
         }
     };
 
@@ -124,57 +117,38 @@ describe("DiscreteSystem", () => {
         const sys = createSystem();
         sys.setStateInitial();
 
-        expectParticleGroupState(sys, 0, 3, expectedGroup1Initial);
-        expectParticleGroupState(sys, 1, 3, expectedGroup2Initial);
+        expectParticleState(sys, 3, expectedInitial);
     });
 
     test("can set substate", () => {
         const sys = createSystem();
         sys.setStateInitial();
-        const subState = [[[17, 18]], [[27, 28]]];
-        sys.setState(subState, [], [2], [3, 4]);
-        expect(arrayStateToArray(sys.state.getParticle(0, 2))).toStrictEqual([
-            999999, // shared.N - shared.I0;
-            1, // shared.I0;
+        const subState = [[17, 18]];
+        sys.setState(subState, [2], [3, 4]);
+        expect(arrayStateToArray(sys.state.getParticle(2))).toStrictEqual([
+            999999, // params.N - params.I0;
+            1, // params.I0;
             0,
             17,
             18
-        ]); // expectedGroup1Initial with the updated values
-        expect(arrayStateToArray(sys.state.getParticle(1, 2))).toStrictEqual([
-            1999998, // shared.N - shared.I0;
-            2, // shared.I0;
-            0,
-            27,
-            28
-        ]); // expectedGroup2Initial with the updated values
+        ]); // expectedIntial with the updated values
     });
 
     test("can set full state", () => {
         const sys = createSystem();
         sys.setStateInitial();
 
-        const newGrp1Part1 = [11111, 1, 2, 3, 4];
-        const newGrp1Part2 = [22222, 2, 3, 4, 5];
-        const newGrp1Part3 = [33333, 3, 4, 5, 6];
+        const newPart1 = [11111, 1, 2, 3, 4];
+        const newPart2 = [22222, 2, 3, 4, 5];
+        const newPart3 = [33333, 3, 4, 5, 6];
 
-        const newGrp2Part1 = [11110, 10, 20, 30, 40];
-        const newGrp2Part2 = [22220, 20, 30, 40, 50];
-        const newGrp2Part3 = [33330, 30, 40, 50, 60];
-
-        const newState = [
-            [newGrp1Part1, newGrp1Part2, newGrp1Part3],
-            [newGrp2Part1, newGrp2Part2, newGrp2Part3]
-        ];
+        const newState = [newPart1, newPart2, newPart3];
 
         sys.setState(newState);
 
-        expect(arrayStateToArray(sys.state.getParticle(0, 0))).toStrictEqual(newGrp1Part1);
-        expect(arrayStateToArray(sys.state.getParticle(0, 1))).toStrictEqual(newGrp1Part2);
-        expect(arrayStateToArray(sys.state.getParticle(0, 2))).toStrictEqual(newGrp1Part3);
-
-        expect(arrayStateToArray(sys.state.getParticle(1, 0))).toStrictEqual(newGrp2Part1);
-        expect(arrayStateToArray(sys.state.getParticle(1, 1))).toStrictEqual(newGrp2Part2);
-        expect(arrayStateToArray(sys.state.getParticle(1, 2))).toStrictEqual(newGrp2Part3);
+        expect(arrayStateToArray(sys.state.getParticle(0))).toStrictEqual(newPart1);
+        expect(arrayStateToArray(sys.state.getParticle(1))).toStrictEqual(newPart2);
+        expect(arrayStateToArray(sys.state.getParticle(2))).toStrictEqual(newPart3);
     });
 
     test("can set and get time", () => {
@@ -188,10 +162,10 @@ describe("DiscreteSystem", () => {
         const random = new Random(rngStateObserved);
         const compareRandom = new Random(rngStateObserved.replay());
         const np = 5;
-        const walkShared = { n: 3, sd: 1 };
-        const sys = System.createDiscrete<WalkShared, null>(
+        const walkParams = { n: 3, sd: 1 };
+        const sys = System.createDiscrete<WalkParams, null>(
             discreteWalk,
-            [walkShared],
+            walkParams,
             0, // time
             1, // dt
             np, // nParticles
@@ -203,7 +177,7 @@ describe("DiscreteSystem", () => {
         for (let i = 0; i < np; i++) {
             const expectedT1 = [...new Array(3)].map((t) => compareRandom.randomNormal());
             const expectedT2 = expectedT1.map((t1) => t1 + compareRandom.randomNormal());
-            const particle = sys.state.getParticle(0, i);
+            const particle = sys.state.getParticle(i);
             expect(arrayStateToArray(particle)).toStrictEqual(expectedT2);
         }
         expect(sys.time).toEqual(2);
@@ -218,9 +192,9 @@ describe("DiscreteSystem", () => {
         const step1 = 5.5;
         const dt = 0.5;
 
-        const sys = System.createDiscrete<SIRShared, null, SIRData>(
+        const sys = System.createDiscrete<SIRParams, null, SIRData>(
             generator,
-            sirShared,
+            sirParams,
             start, // time
             dt, // dt
             2, // nParticles
@@ -230,41 +204,23 @@ describe("DiscreteSystem", () => {
         sys.setStateInitial();
         sys.runToTime(6); // 1 more than start time, should take 2 steps of 0.5
 
-        const g1StartState = [999999, 1, 0, 0, 0];
-        const g2StartState = [1999998, 2, 0, 0, 0];
+        const startState = [999999, 1, 0, 0, 0];
 
         // Simulate each of the updates called by the System, using the compareRandom to replay the
         // same random values in order so we get the same results
-        // 2 Groups (g) and 2 Particles (p)
 
-        // Group 1
-        const g1Shared = sirShared[0];
-        const g1p1Step1State = newSIRState();
-        generator.update(imports, start, dt, g1StartState, g1Shared, null, g1p1Step1State, compareRandom);
-        const g1p1Step2State = newSIRState();
-        generator.update(imports, step1, dt, g1p1Step1State, g1Shared, null, g1p1Step2State, compareRandom);
+        const p1Step1State = newSIRState();
+        generator.update(imports, start, dt, startState, sirParams, null, p1Step1State, compareRandom);
+        const p1Step2State = newSIRState();
+        generator.update(imports, step1, dt, p1Step1State, sirParams, null, p1Step2State, compareRandom);
 
-        const g1p2Step1State = newSIRState();
-        generator.update(imports, start, dt, g1StartState, g1Shared, null, g1p2Step1State, compareRandom);
-        const g1p2Step2State = newSIRState();
-        generator.update(imports, step1, dt, g1p2Step1State, g1Shared, null, g1p2Step2State, compareRandom);
+        const p2Step1State = newSIRState();
+        generator.update(imports, start, dt, startState, sirParams, null, p2Step1State, compareRandom);
+        const p2Step2State = newSIRState();
+        generator.update(imports, step1, dt, p2Step1State, sirParams, null, p2Step2State, compareRandom);
 
-        // Group 2
-        const g2Shared = sirShared[1];
-        const g2p1Step1State = newSIRState();
-        generator.update(imports, start, dt, g2StartState, g2Shared, null, g2p1Step1State, compareRandom);
-        const g2p1Step2State = newSIRState();
-        generator.update(imports, step1, dt, g2p1Step1State, g2Shared, null, g2p1Step2State, compareRandom);
-
-        const g2p2Step1State = newSIRState();
-        generator.update(imports, start, dt, g2StartState, g2Shared, null, g2p2Step1State, compareRandom);
-        const g2p2Step2State = new Array<number>(5);
-        generator.update(imports, step1, dt, g2p2Step1State, g2Shared, null, g2p2Step2State, compareRandom);
-
-        expect(arrayStateToArray(sys.state.getParticle(0, 0))).toStrictEqual(g1p1Step2State);
-        expect(arrayStateToArray(sys.state.getParticle(0, 1))).toStrictEqual(g1p2Step2State);
-        expect(arrayStateToArray(sys.state.getParticle(1, 0))).toStrictEqual(g2p1Step2State);
-        expect(arrayStateToArray(sys.state.getParticle(1, 1))).toStrictEqual(g2p2Step2State);
+        expect(arrayStateToArray(sys.state.getParticle(0))).toStrictEqual(p1Step2State);
+        expect(arrayStateToArray(sys.state.getParticle(1))).toStrictEqual(p2Step2State);
     });
 
     test("throws expected error if run to time which is before current time", () => {
@@ -275,40 +231,23 @@ describe("DiscreteSystem", () => {
         );
     });
 
-    test("can update shared", () => {
+    test("can update params", () => {
         const sys = createSystem();
-        const newShared = [
-            { N: 3000000, I0: 10, beta: 40, gamma: 20 },
-            { N: 4000000, I0: 20, beta: 80, gamma: 40 }
-        ];
-        sys.updateShared(newShared);
-        const sysShared = sys["_shared"];
+        const newParams = { N: 3000000, I0: 10, beta: 40, gamma: 20 };
+        sys.updateParams(newParams);
+        const sysParams = sys["_params"];
         // Expect all values except N to have been updated
-        expect(sysShared[0]).toStrictEqual({ N: 1000000, I0: 10, beta: 40, gamma: 20 });
-        expect(sysShared[1]).toStrictEqual({ N: 2000000, I0: 20, beta: 80, gamma: 40 });
+        expect(sysParams).toStrictEqual({ N: 1000000, I0: 10, beta: 40, gamma: 20 });
     });
 
-    test("throws expected error if update shared with invalid length", () => {
-        const sys = createSystem();
-        const newShared = [{ N: 3000000, I0: 1, beta: 4, gamma: 2 }];
-        expect(() => sys.updateShared(newShared)).toThrowError(
-            "New shared value must be same length as previous value. Expected 2 but got 1."
-        );
-    });
-
-    const simulateShared = [
-        { N: 1000000, I0: 1, beta: 4, gamma: 2 },
-        { N: 2000000, I0: 2, beta: 8, gamma: 4 }
-    ];
-
-    const g1StartState = [999999, 1, 0, 0, 0];
-    const g2StartState = [1999998, 2, 0, 0, 0];
+    const simulateParams = { N: 1000000, I0: 1, beta: 4, gamma: 2 };
+    const startState = [999999, 1, 0, 0, 0];
 
     // Helper for simulate tests - manually run each of the updates called by the System, using the compareRandom to
     // replay the same random values in order so we get the same results
-    const getNextState = (start, currentState, shared, dt, random) => {
+    const getNextState = (start, currentState, params, dt, random) => {
         const nextState = newSIRState();
-        generator.update(imports, start, dt, currentState, shared, null, nextState, random);
+        generator.update(imports, start, dt, currentState, params, null, nextState, random);
         return nextState;
     };
 
@@ -323,9 +262,9 @@ describe("DiscreteSystem", () => {
         const step3 = 6.5;
         const dt = 0.5;
 
-        const sys = System.createDiscrete<SIRShared, null, SIRData>(
+        const sys = System.createDiscrete<SIRParams, null, SIRData>(
             generator,
-            simulateShared,
+            simulateParams,
             start, // time
             dt, // dt
             2, // nParticles
@@ -337,136 +276,51 @@ describe("DiscreteSystem", () => {
         const result = sys.simulate([6, 7], [0, 2, 4]); // 1 and 2 more than start time, should take 4 steps of 0.5
 
         // TIME 6
-        // Group 1
-        const g1Shared = simulateShared[0];
-        const g1p1Step1State = getNextState(start, g1StartState, g1Shared, dt, compareRandom);
-        const g1p1Step2State = getNextState(step1, g1p1Step1State, g1Shared, dt, compareRandom);
+        const p1Step1State = getNextState(start, startState, simulateParams, dt, compareRandom);
+        const p1Step2State = getNextState(step1, p1Step1State, simulateParams, dt, compareRandom);
 
-        const g1p2Step1State = getNextState(start, g1StartState, g1Shared, dt, compareRandom);
-        const g1p2Step2State = getNextState(step1, g1p2Step1State, g1Shared, dt, compareRandom);
-
-        // Group 2
-        const g2Shared = simulateShared[1];
-        const g2p1Step1State = getNextState(start, g2StartState, g2Shared, dt, compareRandom);
-        const g2p1Step2State = getNextState(step1, g2p1Step1State, g2Shared, dt, compareRandom);
-
-        const g2p2Step1State = getNextState(start, g2StartState, g2Shared, dt, compareRandom);
-        const g2p2Step2State = getNextState(step1, g2p2Step1State, g2Shared, dt, compareRandom);
+        const p2Step1State = getNextState(start, startState, simulateParams, dt, compareRandom);
+        const p2Step2State = getNextState(step1, p2Step1State, simulateParams, dt, compareRandom);
 
         // TIME 7
-        // Group 1
-        const g1p1Step3State = getNextState(step2, g1p1Step2State, g1Shared, dt, compareRandom);
-        const g1p1Step4State = getNextState(step3, g1p1Step3State, g1Shared, dt, compareRandom);
+        const p1Step3State = getNextState(step2, p1Step2State, simulateParams, dt, compareRandom);
+        const p1Step4State = getNextState(step3, p1Step3State, simulateParams, dt, compareRandom);
 
-        const g1p2Step3State = getNextState(step2, g1p2Step2State, g1Shared, dt, compareRandom);
-        const g1p2Step4State = getNextState(step3, g1p2Step3State, g1Shared, dt, compareRandom);
-
-        // Group 2
-        const g2p1Step3State = getNextState(step2, g2p1Step2State, g2Shared, dt, compareRandom);
-        const g2p1Step4State = getNextState(step3, g2p1Step3State, g2Shared, dt, compareRandom);
-
-        const g2p2Step3State = getNextState(step2, g2p2Step2State, g2Shared, dt, compareRandom);
-        const g2p2Step4State = getNextState(step3, g2p2Step3State, g2Shared, dt, compareRandom);
+        const p2Step3State = getNextState(step2, p2Step2State, simulateParams, dt, compareRandom);
+        const p2Step4State = getNextState(step3, p2Step3State, simulateParams, dt, compareRandom);
 
         // Test can get expected state element values for both times
         // State element indexes 0, 1, 2 in result should map to 0, 2, 4 in full state
-        // Group 1
-        expect(arrayStateToArray(result.getStateElement(0, 0, 0))).toStrictEqual([
-            g1p1Step2State[0],
-            g1p1Step4State[0]
-        ]);
-        expect(arrayStateToArray(result.getStateElement(0, 0, 1))).toStrictEqual([
-            g1p1Step2State[2],
-            g1p1Step4State[2]
-        ]);
-        expect(arrayStateToArray(result.getStateElement(0, 0, 2))).toStrictEqual([
-            g1p1Step2State[4],
-            g1p1Step4State[4]
-        ]);
+        expect(arrayStateToArray(result.getStateElement(0, 0))).toStrictEqual([p1Step2State[0], p1Step4State[0]]);
+        expect(arrayStateToArray(result.getStateElement(0, 1))).toStrictEqual([p1Step2State[2], p1Step4State[2]]);
+        expect(arrayStateToArray(result.getStateElement(0, 2))).toStrictEqual([p1Step2State[4], p1Step4State[4]]);
 
-        expect(arrayStateToArray(result.getStateElement(0, 1, 0))).toStrictEqual([
-            g1p2Step2State[0],
-            g1p2Step4State[0]
-        ]);
-        expect(arrayStateToArray(result.getStateElement(0, 1, 1))).toStrictEqual([
-            g1p2Step2State[2],
-            g1p2Step4State[2]
-        ]);
-        expect(arrayStateToArray(result.getStateElement(0, 1, 2))).toStrictEqual([
-            g1p2Step2State[4],
-            g1p2Step4State[4]
-        ]);
-
-        // Group 2
-        expect(arrayStateToArray(result.getStateElement(1, 0, 0))).toStrictEqual([
-            g2p1Step2State[0],
-            g2p1Step4State[0]
-        ]);
-        expect(arrayStateToArray(result.getStateElement(1, 0, 1))).toStrictEqual([
-            g2p1Step2State[2],
-            g2p1Step4State[2]
-        ]);
-        expect(arrayStateToArray(result.getStateElement(1, 0, 2))).toStrictEqual([
-            g2p1Step2State[4],
-            g2p1Step4State[4]
-        ]);
-
-        expect(arrayStateToArray(result.getStateElement(1, 1, 0))).toStrictEqual([
-            g2p2Step2State[0],
-            g2p2Step4State[0]
-        ]);
-        expect(arrayStateToArray(result.getStateElement(1, 1, 1))).toStrictEqual([
-            g2p2Step2State[2],
-            g2p2Step4State[2]
-        ]);
-        expect(arrayStateToArray(result.getStateElement(1, 1, 2))).toStrictEqual([
-            g2p2Step2State[4],
-            g2p2Step4State[4]
-        ]);
+        expect(arrayStateToArray(result.getStateElement(1, 0))).toStrictEqual([p2Step2State[0], p2Step4State[0]]);
+        expect(arrayStateToArray(result.getStateElement(1, 1))).toStrictEqual([p2Step2State[2], p2Step4State[2]]);
+        expect(arrayStateToArray(result.getStateElement(1, 2))).toStrictEqual([p2Step2State[4], p2Step4State[4]]);
 
         // Test can get get all state values for a time (for a particle) - NB "iTime" param here is time index,
         // not time value.
         // Group 1
-        expect(arrayStateToArray(result.getValuesForTime(0, 0, 0))).toStrictEqual([
-            g1p1Step2State[0],
-            g1p1Step2State[2],
-            g1p1Step2State[4]
+        expect(arrayStateToArray(result.getValuesForTime(0, 0))).toStrictEqual([
+            p1Step2State[0],
+            p1Step2State[2],
+            p1Step2State[4]
         ]);
-        expect(arrayStateToArray(result.getValuesForTime(0, 0, 1))).toStrictEqual([
-            g1p1Step4State[0],
-            g1p1Step4State[2],
-            g1p1Step4State[4]
+        expect(arrayStateToArray(result.getValuesForTime(0, 1))).toStrictEqual([
+            p1Step4State[0],
+            p1Step4State[2],
+            p1Step4State[4]
         ]);
-        expect(arrayStateToArray(result.getValuesForTime(0, 1, 0))).toStrictEqual([
-            g1p2Step2State[0],
-            g1p2Step2State[2],
-            g1p2Step2State[4]
+        expect(arrayStateToArray(result.getValuesForTime(1, 0))).toStrictEqual([
+            p2Step2State[0],
+            p2Step2State[2],
+            p2Step2State[4]
         ]);
-        expect(arrayStateToArray(result.getValuesForTime(0, 1, 1))).toStrictEqual([
-            g1p2Step4State[0],
-            g1p2Step4State[2],
-            g1p2Step4State[4]
-        ]);
-        // Group 2
-        expect(arrayStateToArray(result.getValuesForTime(1, 0, 0))).toStrictEqual([
-            g2p1Step2State[0],
-            g2p1Step2State[2],
-            g2p1Step2State[4]
-        ]);
-        expect(arrayStateToArray(result.getValuesForTime(1, 0, 1))).toStrictEqual([
-            g2p1Step4State[0],
-            g2p1Step4State[2],
-            g2p1Step4State[4]
-        ]);
-        expect(arrayStateToArray(result.getValuesForTime(1, 1, 0))).toStrictEqual([
-            g2p2Step2State[0],
-            g2p2Step2State[2],
-            g2p2Step2State[4]
-        ]);
-        expect(arrayStateToArray(result.getValuesForTime(1, 1, 1))).toStrictEqual([
-            g2p2Step4State[0],
-            g2p2Step4State[2],
-            g2p2Step4State[4]
+        expect(arrayStateToArray(result.getValuesForTime(1, 1))).toStrictEqual([
+            p2Step4State[0],
+            p2Step4State[2],
+            p2Step4State[4]
         ]);
     });
 
@@ -479,9 +333,9 @@ describe("DiscreteSystem", () => {
         const step1 = 5.5;
         const dt = 0.5;
 
-        const sys = System.createDiscrete<SIRShared, null, SIRData>(
+        const sys = System.createDiscrete<SIRParams, null, SIRData>(
             generator,
-            simulateShared,
+            simulateParams,
             start, // time
             dt, // dt
             1, // nParticles
@@ -493,39 +347,22 @@ describe("DiscreteSystem", () => {
         const result = sys.simulate([5, 6]); // 0 and 1 more than start time, should take 2 steps of 0.5
 
         // TIME 6
-        // Group 1
-        const g1Shared = simulateShared[0];
-        const g1p1Step1State = getNextState(start, g1StartState, g1Shared, dt, compareRandom);
-        const g1p1Step2State = getNextState(step1, g1p1Step1State, g1Shared, dt, compareRandom);
-
-        // Group 2
-        const g2Shared = simulateShared[1];
-        const g2p1Step1State = getNextState(start, g2StartState, g2Shared, dt, compareRandom);
-        const g2p1Step2State = getNextState(step1, g2p1Step1State, g2Shared, dt, compareRandom);
+        const p1Step1State = getNextState(start, startState, simulateParams, dt, compareRandom);
+        const p1Step2State = getNextState(step1, p1Step1State, simulateParams, dt, compareRandom);
 
         // Test can get expected state element values for both times
 
         [...Array(5).keys()].map((stateElIdx) => {
             // Group 1
-            expect(arrayStateToArray(result.getStateElement(0, 0, stateElIdx))).toStrictEqual([
-                g1StartState[stateElIdx],
-                g1p1Step2State[stateElIdx]
-            ]);
-            // Group 2
-            expect(arrayStateToArray(result.getStateElement(1, 0, stateElIdx))).toStrictEqual([
-                g2StartState[stateElIdx],
-                g2p1Step2State[stateElIdx]
+            expect(arrayStateToArray(result.getStateElement(0, stateElIdx))).toStrictEqual([
+                startState[stateElIdx],
+                p1Step2State[stateElIdx]
             ]);
         });
 
         // Test can get get all state values for a time (for a particle)
-        // Group 1
-        expect(arrayStateToArray(result.getValuesForTime(0, 0, 0))).toStrictEqual(g1StartState);
-        expect(arrayStateToArray(result.getValuesForTime(0, 0, 1))).toStrictEqual(g1p1Step2State);
-
-        // Group 2
-        expect(arrayStateToArray(result.getValuesForTime(1, 0, 0))).toStrictEqual(g2StartState);
-        expect(arrayStateToArray(result.getValuesForTime(1, 0, 1))).toStrictEqual(g2p1Step2State);
+        expect(arrayStateToArray(result.getValuesForTime(0, 0))).toStrictEqual(startState);
+        expect(arrayStateToArray(result.getValuesForTime(0, 1))).toStrictEqual(p1Step2State);
     });
 
     test("simulate throws error if times are not valid", () => {

--- a/tests/SystemSimulateResult.test.ts
+++ b/tests/SystemSimulateResult.test.ts
@@ -4,116 +4,96 @@ import { particleStateToArray, arrayStateToArray } from "../src/utils";
 
 describe("SystemSimulateResult", () => {
     test("can get values for time", () => {
-        const sut = new SystemSimulateResult(2, 3, 4, 2);
+        const sut = new SystemSimulateResult(3, 4, 2);
 
-        sut.setValuesForTime(0, 0, 0, [1, 2, 3, 4]);
-        sut.setValuesForTime(1, 2, 1, [9, 8, 7, 6]);
+        sut.setValuesForTime(0, 0, [1, 2, 3, 4]);
 
-        const t0Vals = sut.getValuesForTime(0, 0, 0);
+        const t0Vals = sut.getValuesForTime(0, 0);
         expect(particleStateToArray(t0Vals)).toStrictEqual([1, 2, 3, 4]);
-
-        const t1Vals = sut.getValuesForTime(1, 2, 1);
-        expect(particleStateToArray(t1Vals)).toStrictEqual([9, 8, 7, 6]);
     });
 
     test("can get state element values", () => {
-        const sut = new SystemSimulateResult(2, 2, 4, 2);
-        sut.setValuesForTime(0, 0, 0, [100, 200, 300, 400]);
-        sut.setValuesForTime(0, 1, 0, [101, 201, 301, 401]);
-        sut.setValuesForTime(0, 0, 1, [900, 800, 700, 600]);
-        sut.setValuesForTime(0, 1, 1, [901, 801, 701, 601]);
+        const sut = new SystemSimulateResult(2, 4, 2);
+        sut.setValuesForTime(0, 0, [100, 200, 300, 400]);
+        sut.setValuesForTime(1, 0, [101, 201, 301, 401]);
+        sut.setValuesForTime(0, 1, [900, 800, 700, 600]);
+        sut.setValuesForTime(1, 1, [901, 801, 701, 601]);
 
-        expect(arrayStateToArray(sut.getStateElement(0, 0, 0))).toStrictEqual([100, 900]);
-        expect(arrayStateToArray(sut.getStateElement(0, 0, 1))).toStrictEqual([200, 800]);
-        expect(arrayStateToArray(sut.getStateElement(0, 0, 2))).toStrictEqual([300, 700]);
-        expect(arrayStateToArray(sut.getStateElement(0, 0, 3))).toStrictEqual([400, 600]);
+        expect(arrayStateToArray(sut.getStateElement(0, 0))).toStrictEqual([100, 900]);
+        expect(arrayStateToArray(sut.getStateElement(0, 1))).toStrictEqual([200, 800]);
+        expect(arrayStateToArray(sut.getStateElement(0, 2))).toStrictEqual([300, 700]);
+        expect(arrayStateToArray(sut.getStateElement(0, 3))).toStrictEqual([400, 600]);
 
-        expect(arrayStateToArray(sut.getStateElement(0, 1, 0))).toStrictEqual([101, 901]);
-        expect(arrayStateToArray(sut.getStateElement(0, 1, 1))).toStrictEqual([201, 801]);
-        expect(arrayStateToArray(sut.getStateElement(0, 1, 2))).toStrictEqual([301, 701]);
-        expect(arrayStateToArray(sut.getStateElement(0, 1, 3))).toStrictEqual([401, 601]);
+        expect(arrayStateToArray(sut.getStateElement(1, 0))).toStrictEqual([101, 901]);
+        expect(arrayStateToArray(sut.getStateElement(1, 1))).toStrictEqual([201, 801]);
+        expect(arrayStateToArray(sut.getStateElement(1, 2))).toStrictEqual([301, 701]);
+        expect(arrayStateToArray(sut.getStateElement(1, 3))).toStrictEqual([401, 601]);
     });
 
     test("constructor validates size parameters", () => {
-        expect(() => new SystemSimulateResult(0, 1, 2, 3)).toThrowError(
-            "Number of groups should be an integer greater than or equal to 1, but is 0."
-        );
-        expect(() => new SystemSimulateResult(1, -1, 2, 3)).toThrowError(
+        expect(() => new SystemSimulateResult(-1, 2, 3)).toThrowError(
             "Number of particles should be an integer greater than or equal to 1, but is -1."
         );
-        expect(() => new SystemSimulateResult(1, 1, 0, 3)).toThrowError(
+        expect(() => new SystemSimulateResult(1, 0, 3)).toThrowError(
             "Number of state elements should be an integer greater than or equal to 1, but is 0."
         );
-        expect(() => new SystemSimulateResult(1, 1, 1)).toThrowError(
+        expect(() => new SystemSimulateResult(1, 1, undefined as any)).toThrowError(
             "Number of times should be an integer greater than or equal to 1, but is undefined."
         );
     });
 
     test("setValuesForTime checks indexes", () => {
-        const sut = new SystemSimulateResult(2, 3, 4, 5);
+        const sut = new SystemSimulateResult(3, 4, 5);
 
         // Can set max index value for all dimensions
-        sut.setValuesForTime(1, 2, 4, [10, 20, 30, 40]);
-        expect(arrayStateToArray(sut.getValuesForTime(1, 2, 4))).toStrictEqual([10, 20, 30, 40]);
+        sut.setValuesForTime(2, 4, [10, 20, 30, 40]);
+        expect(arrayStateToArray(sut.getValuesForTime(2, 4))).toStrictEqual([10, 20, 30, 40]);
 
-        expect(() => sut.setValuesForTime(2, 2, 4, [10, 20, 30, 40])).toThrowError(
-            "Group index should be an integer between 0 and 1, but is 2."
-        );
-        expect(() => sut.setValuesForTime(-1, 2, 4, [10, 20, 30, 40])).toThrowError(
-            "Group index should be an integer between 0 and 1, but is -1."
-        );
-
-        expect(() => sut.setValuesForTime(0, 3, 4, [10, 20, 30, 40])).toThrowError(
+        expect(() => sut.setValuesForTime(3, 4, [10, 20, 30, 40])).toThrowError(
             "Particle index should be an integer between 0 and 2, but is 3."
         );
-        expect(() => sut.setValuesForTime(0, -1.3, 4, [10, 20, 30, 40])).toThrowError(
+        expect(() => sut.setValuesForTime(-1.3, 4, [10, 20, 30, 40])).toThrowError(
             "Particle index should be an integer between 0 and 2, but is -1.3."
         );
 
-        expect(() => sut.setValuesForTime(0, 1, 5, [10, 20, 30, 40])).toThrowError(
+        expect(() => sut.setValuesForTime(1, 5, [10, 20, 30, 40])).toThrowError(
             "Time index should be an integer between 0 and 4, but is 5."
         );
-        expect(() => sut.setValuesForTime(0, 1, 3.9, [10, 20, 30, 40])).toThrowError(
+        expect(() => sut.setValuesForTime(1, 3.9, [10, 20, 30, 40])).toThrowError(
             "Time index should be an integer between 0 and 4, but is 3.9."
         );
     });
 
     test("setValuesForTime checks values size", () => {
-        const sut = new SystemSimulateResult(2, 3, 4, 5);
-        expect(() => sut.setValuesForTime(1, 2, 4, [10, 20, 30])).toThrowError("Expected 4 state values but got 3.");
-        expect(() => sut.setValuesForTime(1, 2, 4, [10, 20, 30, 40, 50])).toThrowError(
+        const sut = new SystemSimulateResult(3, 4, 5);
+        expect(() => sut.setValuesForTime(2, 4, [10, 20, 30])).toThrowError("Expected 4 state values but got 3.");
+        expect(() => sut.setValuesForTime(2, 4, [10, 20, 30, 40, 50])).toThrowError(
             "Expected 4 state values but got 5."
         );
     });
 
     test("getValuesForTime checks indexes", () => {
-        const sut = new SystemSimulateResult(2, 3, 4, 5);
-        expect(() => sut.getValuesForTime(2, 2, 2)).toThrow(
-            "Group index should be an integer between 0 and 1, but is 2."
-        );
-        expect(() => sut.getValuesForTime(1, 3, 4)).toThrow(
+        const sut = new SystemSimulateResult(3, 4, 5);
+        expect(() => sut.getValuesForTime(3, 4)).toThrow(
             "Particle index should be an integer between 0 and 2, but is 3."
         );
-        expect(() => sut.getValuesForTime(1, 1, 40)).toThrow(
+        expect(() => sut.getValuesForTime(1, 40)).toThrow(
             "Time index should be an integer between 0 and 4, but is 40."
         );
     });
 
     test("getStateElement checks indexes", () => {
-        const sut = new SystemSimulateResult(2, 3, 4, 5);
-        expect(() => sut.getStateElement(2, 2, 2)).toThrow(
-            "Group index should be an integer between 0 and 1, but is 2."
-        );
-        expect(() => sut.getStateElement(1, 3, 4)).toThrow(
+        const sut = new SystemSimulateResult(3, 4, 5);
+        expect(() => sut.getStateElement(3, 4)).toThrow(
             "Particle index should be an integer between 0 and 2, but is 3."
         );
-        expect(() => sut.getStateElement(1, 1, 40)).toThrow(
+        expect(() => sut.getStateElement(1, 40)).toThrow(
             "State Element index should be an integer between 0 and 3, but is 40."
         );
     });
 
     test("can get resultValues ndArray", () => {
-        const sut = new SystemSimulateResult(2, 3, 4, 5);
-        expect(sut.resultValues().size).toBe(2 * 3 * 4 * 5);
+        const sut = new SystemSimulateResult(3, 4, 5);
+        expect(sut.resultValues().size).toBe(3 * 4 * 5);
     });
 });

--- a/tests/SystemState.test.ts
+++ b/tests/SystemState.test.ts
@@ -4,11 +4,7 @@ import { ndArrayFrom, arrayStateToArray } from "../src/utils.ts";
 import ndarray from "ndarray";
 
 describe("SystemState", () => {
-    const createSystemState = () => new SystemState(2, 3, 4);
-
-    test("can get nGroups", () => {
-        expect(createSystemState().nGroups).toBe(2);
-    });
+    const createSystemState = () => new SystemState(3, 4);
 
     test("can get nParticles", () => {
         expect(createSystemState().nParticles).toBe(3);
@@ -20,125 +16,69 @@ describe("SystemState", () => {
 
     test("can set and get particles", () => {
         const sut = createSystemState();
-        sut.setParticle(0, 1, [10, 20, 30, 40]);
-        sut.setParticle(1, 2, [50, 60, 70, 80]);
+        sut.setParticle(1, [10, 20, 30, 40]);
 
-        expect(arrayStateToArray(sut.getParticle(0, 1))).toStrictEqual([10, 20, 30, 40]);
-        expect(arrayStateToArray(sut.getParticle(1, 2))).toStrictEqual([50, 60, 70, 80]);
+        expect(arrayStateToArray(sut.getParticle(1))).toStrictEqual([10, 20, 30, 40]);
     });
 
     test("throws error when attempt get with invalid index", () => {
         const sut = createSystemState();
-        expect(() => sut.getParticle(2, 2)).toThrowError("Group index should be an integer between 0 and 1, but is 2.");
-        expect(() => sut.getParticle(1, 3)).toThrowError(
-            "Particle index should be an integer between 0 and 2, but is 3."
-        );
-        expect(() => sut.getParticle(0.5, 2)).toThrowError(
-            "Group index should be an integer between 0 and 1, but is 0.5."
-        );
-        expect(() => sut.getParticle(1, 1.1)).toThrowError(
-            "Particle index should be an integer between 0 and 2, but is 1.1."
-        );
-    });
-
-    test("throws error when attempt set with invalid index", () => {
-        const sut = createSystemState();
-        const vals = [1, 2, 3, 4];
-        expect(() => sut.setParticle(2, 2, vals)).toThrowError(
-            "Group index should be an integer between 0 and 1, but is 2."
-        );
-        expect(() => sut.setParticle(1, 3, vals)).toThrowError(
-            "Particle index should be an integer between 0 and 2, but is 3."
-        );
-        expect(() => sut.setParticle(0.5, 2, vals)).toThrowError(
-            "Group index should be an integer between 0 and 1, but is 0.5."
-        );
-        expect(() => sut.setParticle(1, 1.1, vals)).toThrowError(
+        expect(() => sut.getParticle(3)).toThrowError("Particle index should be an integer between 0 and 2, but is 3.");
+        expect(() => sut.getParticle(1.1)).toThrowError(
             "Particle index should be an integer between 0 and 2, but is 1.1."
         );
     });
 
     test("throws error when attempt set with array of incorrect length", () => {
         const sut = createSystemState();
-        expect(() => sut.setParticle(0, 0, [0, 1])).toThrowError("Particle state array must be of length 4.");
+        expect(() => sut.setParticle(0, [0, 1])).toThrowError("Particle state array must be of length 4.");
     });
 
     const createSystemStateForReorder = () => {
-        const sut = new SystemState(2, 3, 2);
+        const sut = new SystemState(3, 2);
 
         // Initial State
-        // Group 0
-        sut.setParticle(0, 0, [1, 2]);
-        sut.setParticle(0, 1, [3, 4]);
-        sut.setParticle(0, 2, [5, 6]);
-        // Group 1
-        sut.setParticle(1, 0, [10, 20]);
-        sut.setParticle(1, 1, [30, 40]);
-        sut.setParticle(1, 2, [50, 60]);
+        sut.setParticle(0, [1, 2]);
+        sut.setParticle(1, [3, 4]);
+        sut.setParticle(2, [5, 6]);
         return sut;
     };
 
     test("can reorder particles", () => {
         const sut = createSystemStateForReorder();
-        let reordering = ndArrayFrom([
-            [1, 2, 0],
-            [2, 0, 1]
-        ]);
+        let reordering = ndArrayFrom([1, 2, 0]);
         sut.reorder(reordering);
 
-        expect(arrayStateToArray(sut.getParticle(0, 0))).toStrictEqual([3, 4]);
-        expect(arrayStateToArray(sut.getParticle(0, 1))).toStrictEqual([5, 6]);
-        expect(arrayStateToArray(sut.getParticle(0, 2))).toStrictEqual([1, 2]);
-
-        expect(arrayStateToArray(sut.getParticle(1, 0))).toStrictEqual([50, 60]);
-        expect(arrayStateToArray(sut.getParticle(1, 1))).toStrictEqual([10, 20]);
-        expect(arrayStateToArray(sut.getParticle(1, 2))).toStrictEqual([30, 40]);
+        expect(arrayStateToArray(sut.getParticle(0))).toStrictEqual([3, 4]);
+        expect(arrayStateToArray(sut.getParticle(1))).toStrictEqual([5, 6]);
+        expect(arrayStateToArray(sut.getParticle(2))).toStrictEqual([1, 2]);
 
         // Test that successive reordering work as expected
-        reordering = ndArrayFrom([
-            [2, 1, 0],
-            [1, 0, 2]
-        ]);
+        reordering = ndArrayFrom([2, 1, 0]);
         sut.reorder(reordering);
-        expect(arrayStateToArray(sut.getParticle(0, 0))).toStrictEqual([1, 2]);
-        expect(arrayStateToArray(sut.getParticle(0, 1))).toStrictEqual([5, 6]);
-        expect(arrayStateToArray(sut.getParticle(0, 2))).toStrictEqual([3, 4]);
-
-        expect(arrayStateToArray(sut.getParticle(1, 0))).toStrictEqual([10, 20]);
-        expect(arrayStateToArray(sut.getParticle(1, 1))).toStrictEqual([50, 60]);
-        expect(arrayStateToArray(sut.getParticle(1, 2))).toStrictEqual([30, 40]);
+        expect(arrayStateToArray(sut.getParticle(0))).toStrictEqual([1, 2]);
+        expect(arrayStateToArray(sut.getParticle(1))).toStrictEqual([5, 6]);
+        expect(arrayStateToArray(sut.getParticle(2))).toStrictEqual([3, 4]);
     });
 
     test("can reorder particles with filter and repetition", () => {
         const sut = createSystemStateForReorder();
-        const reordering = ndArrayFrom([
-            [1, 2, 0],
-            [2, 0, 2]
-        ]);
+        const reordering = ndArrayFrom([2, 0, 2]);
         sut.reorder(reordering);
-        expect(arrayStateToArray(sut.getParticle(0, 0))).toStrictEqual([3, 4]);
-        expect(arrayStateToArray(sut.getParticle(0, 1))).toStrictEqual([5, 6]);
-        expect(arrayStateToArray(sut.getParticle(0, 2))).toStrictEqual([1, 2]);
-
-        expect(arrayStateToArray(sut.getParticle(1, 0))).toStrictEqual([50, 60]);
-        expect(arrayStateToArray(sut.getParticle(1, 1))).toStrictEqual([10, 20]);
-        expect(arrayStateToArray(sut.getParticle(1, 2))).toStrictEqual([50, 60]);
+        expect(arrayStateToArray(sut.getParticle(0))).toStrictEqual([5, 6]);
+        expect(arrayStateToArray(sut.getParticle(1))).toStrictEqual([1, 2]);
+        expect(arrayStateToArray(sut.getParticle(2))).toStrictEqual([5, 6]);
     });
 
     test("throws error when attempt to reorder with unexpected reordering shape", () => {
-        const sut = new SystemState(2, 3, 2);
-        const reordering = ndarray(new Int32Array(4), [2, 2]);
-        expect(() => sut.reorder(reordering)).toThrowError(
-            "Unexpected reordering shape. Expected [2,3] but got [2,2]."
-        );
+        const sut = new SystemState(3, 2);
+        const reordering = ndarray(new Int32Array(4), [2]);
+        expect(() => sut.reorder(reordering)).toThrowError("Unexpected reordering shape. Expected [3] but got [2].");
     });
 
     test("throws error when attempt to reorder with negative index", () => {
         const sut = createSystemStateForReorder();
-        const reordering = ndArrayFrom([
-            [-1, 2, 0],
-            [2, 0, 2]
-        ]);
+        const reordering = ndArrayFrom([-1, 2, 0]);
         expect(() => sut.reorder(reordering)).toThrowError(
             "Reordering index should be an integer between 0 and 2, but is -1."
         );
@@ -146,107 +86,66 @@ describe("SystemState", () => {
 
     test("throws error when attempt to reorder with index greater than max", () => {
         const sut = createSystemStateForReorder();
-        const reordering = ndArrayFrom([
-            [1, 2, 0],
-            [20, 0, 2]
-        ]);
+        const reordering = ndArrayFrom([20, 0, 2]);
         expect(() => sut.reorder(reordering)).toThrowError(
             "Reordering index should be an integer between 0 and 2, but is 20."
         );
     });
 
     test("can set full state", () => {
-        const sut = createSystemState(); // 2, 3, 4
+        const sut = createSystemState(); // 3, 4
         const fullState: SystemSubState = [
-            [
-                [0, 1, 2, 3],
-                [4, 5, 6, 7],
-                [8, 9, 10, 11]
-            ],
-            [
-                [100, 101, 102, 103],
-                [104, 105, 106, 107],
-                [108, 109, 110, 111]
-            ]
+            [0, 1, 2, 3],
+            [4, 5, 6, 7],
+            [8, 9, 10, 11]
         ];
         sut.setState(fullState);
-        expect(arrayStateToArray(sut.getParticle(0, 0))).toStrictEqual([0, 1, 2, 3]);
-        expect(arrayStateToArray(sut.getParticle(0, 1))).toStrictEqual([4, 5, 6, 7]);
-        expect(arrayStateToArray(sut.getParticle(0, 2))).toStrictEqual([8, 9, 10, 11]);
-
-        expect(arrayStateToArray(sut.getParticle(1, 0))).toStrictEqual([100, 101, 102, 103]);
-        expect(arrayStateToArray(sut.getParticle(1, 1))).toStrictEqual([104, 105, 106, 107]);
-        expect(arrayStateToArray(sut.getParticle(1, 2))).toStrictEqual([108, 109, 110, 111]);
+        expect(arrayStateToArray(sut.getParticle(0))).toStrictEqual([0, 1, 2, 3]);
+        expect(arrayStateToArray(sut.getParticle(1))).toStrictEqual([4, 5, 6, 7]);
+        expect(arrayStateToArray(sut.getParticle(2))).toStrictEqual([8, 9, 10, 11]);
     });
 
     test("can set substate", () => {
-        const sut = createSystemState(); // 2, 3, 4
-        const subState: SystemSubState = [[[98, 76]], [[54, 32]]];
+        const sut = createSystemState(); // 3, 4
+        const subState: SystemSubState = [[98, 76]];
 
-        // both groups, 2nd particle only, 2nd and 4th state elements
-        sut.setState(subState, [0, 1], [1], [1, 3]);
-        expect(arrayStateToArray(sut.getParticle(0, 0))).toStrictEqual([0, 0, 0, 0]);
-        expect(arrayStateToArray(sut.getParticle(0, 1))).toStrictEqual([0, 98, 0, 76]);
-        expect(arrayStateToArray(sut.getParticle(0, 2))).toStrictEqual([0, 0, 0, 0]);
-
-        expect(arrayStateToArray(sut.getParticle(1, 0))).toStrictEqual([0, 0, 0, 0]);
-        expect(arrayStateToArray(sut.getParticle(1, 1))).toStrictEqual([0, 54, 0, 32]);
-        expect(arrayStateToArray(sut.getParticle(1, 2))).toStrictEqual([0, 0, 0, 0]);
+        // 2nd particle only, 2nd and 4th state elements
+        sut.setState(subState, [1], [1, 3]);
+        expect(arrayStateToArray(sut.getParticle(0))).toStrictEqual([0, 0, 0, 0]);
+        expect(arrayStateToArray(sut.getParticle(1))).toStrictEqual([0, 98, 0, 76]);
+        expect(arrayStateToArray(sut.getParticle(2))).toStrictEqual([0, 0, 0, 0]);
     });
 
     test("throws expected error when full state is the wrong shape", () => {
         const sut = createSystemState(); // 2, 3, 4
         const fullState: SystemSubState = [
-            [
-                [0, 1, 2, 3],
-                [4, 5, 6, 7],
-                [8, 9, 10, 11, 11]
-            ],
-            [
-                [100, 101, 102, 103],
-                [104, 105, 106, 107],
-                [108, 109, 110, 111]
-            ]
+            [0, 1, 2, 3],
+            [4, 5, 6, 7],
+            [8, 9, 10, 11, 11]
         ];
-        expect(() => sut.setState(fullState)).toThrow("State Elements should have length 4 but was 5 at index 0,2");
+        expect(() => sut.setState(fullState)).toThrow("State Elements should have length 4 but was 5 at index 2");
     });
 
     test("throws expected error when substate is the wrong shape", () => {
         const sut = createSystemState(); // 2, 3, 4
-        const subState: SystemSubState = [[[98, 76]], [[54, 32]]];
+        const subState: SystemSubState = [[98, 76]];
 
-        expect(() => sut.setState(subState, [0, 1], [0, 1], [1, 3])).toThrow(
-            "Particles should have length 2 but was 1 at index 0"
-        );
+        expect(() => sut.setState(subState, [0, 1], [1, 3])).toThrow("Particles should have length 2 but was 1");
     });
 
     test("throws expected error when substate indices are invalid for system", () => {
         const sut = createSystemState();
-        const subState: SystemSubState = [[[98, 76]], [[54, 32]]];
-        expect(() => sut.setState(subState, [0, 1], [8], [1, 3])).toThrow(
+        const subState: SystemSubState = [[98, 76]];
+        expect(() => sut.setState(subState, [8], [1, 3])).toThrow(
             "Particle index should be an integer between 0 and 2, but is 8"
         );
     });
 
     test("throws expected error when substate indices are invalid", () => {
         const sut = createSystemState();
-        const subState: SystemSubState = [[[98, 76]], [[54, 32]]];
-        expect(() => sut.setState(subState, [0, -1], [1], [1, 3])).toThrow(
-            "Group index should be an integer between 0 and 1, but is -1"
-        );
-    });
-
-    test("throws expected error when substate indices are not compatible with provided substate", () => {
-        const sut = createSystemState();
-        const subState: SystemSubState = [
-            [
-                [98, 76],
-                [98, 76]
-            ],
-            [[54, 32]]
-        ];
-        expect(() => sut.setState(subState, [0, 1], [0, 1], [1, 3])).toThrow(
-            "newState Particles should have length 2 but was 1 at index 1"
+        const subState: SystemSubState = [[98, 76]];
+        expect(() => sut.setState(subState, [-1], [1, 3])).toThrow(
+            "Particle index should be an integer between 0 and 2, but is -1"
         );
     });
 });

--- a/tests/ZeroEvery.test.ts
+++ b/tests/ZeroEvery.test.ts
@@ -4,10 +4,10 @@ import { ABState, zeroTwice } from "./examples/zeroTwice";
 
 const generator = zeroTwice;
 
-const createSystem = (shared: ABState) =>
+const createSystem = (params: ABState) =>
     System.createDiscrete(
         generator,
-        shared,
+        params,
         0, // time
         1, // dt
         1 // nParticles
@@ -15,9 +15,9 @@ const createSystem = (shared: ABState) =>
 
 // TODO: remove when mrc-6246 is added
 // https://mrc-ide.myjetbrains.com/youtrack/agiles/103-79/current?issue=mrc-6246
-const simulateToTime = (shared: ABState, time: number) => {
+const simulateToTime = (params: ABState, time: number) => {
     const ret = { a: [] as number[], b: [] as number[] };
-    const sys = createSystem(shared);
+    const sys = createSystem(params);
     sys.setStateInitial();
     for (let i = 1; i < time + 1; i++) {
         sys.runToTime(i);

--- a/tests/ZeroEvery.test.ts
+++ b/tests/ZeroEvery.test.ts
@@ -7,7 +7,7 @@ const generator = zeroTwice;
 const createSystem = (shared: ABState) =>
     System.createDiscrete(
         generator,
-        [shared],
+        shared,
         0, // time
         1, // dt
         1 // nParticles
@@ -21,8 +21,8 @@ const simulateToTime = (shared: ABState, time: number) => {
     sys.setStateInitial();
     for (let i = 1; i < time + 1; i++) {
         sys.runToTime(i);
-        ret.a.push(sys.state.getParticle(0, 0).get(0));
-        ret.b.push(sys.state.getParticle(0, 0).get(1));
+        ret.a.push(sys.state.getParticle(0).get(0));
+        ret.b.push(sys.state.getParticle(0).get(1));
     }
     return ret;
 };

--- a/tests/examples/SIRTestHelpers.ts
+++ b/tests/examples/SIRTestHelpers.ts
@@ -1,19 +1,8 @@
-export const sirShared = [
-    { N: 1000000, I0: 1, beta: 4, gamma: 2 },
-    { N: 2000000, I0: 2, beta: 8, gamma: 4 }
-];
+export const sirParams = { N: 1000000, I0: 1, beta: 4, gamma: 2 };
 
-export const expectedGroup1Initial = [
+export const expectedInitial = [
     999999, // shared.N - shared.I0;
     1, // shared.I0;
-    0,
-    0,
-    0
-];
-
-export const expectedGroup2Initial = [
-    1999998, // shared.N - shared.I0;
-    2, // shared.I0;
     0,
     0,
     0

--- a/tests/examples/constantGrad.ts
+++ b/tests/examples/constantGrad.ts
@@ -1,14 +1,14 @@
 import type { ContinuousGeneratorODE } from "../../src/interfaces/generators/ContinuousGenerator.ts";
 
-export interface ConstantGradShared {
+export interface ConstantGradParams {
     y: number;
     yAddOne: number;
 }
 
-export const constantGrad: ContinuousGeneratorODE<ConstantGradShared, null, null> = {
-    initial(_imports, time: number, shared, internal: null, stateNext: number[]) {
-        stateNext[0] = shared.y;
-        stateNext[1] = shared.yAddOne;
+export const constantGrad: ContinuousGeneratorODE<ConstantGradParams, null, null> = {
+    initial(_imports, time: number, params, internal: null, stateNext: number[]) {
+        stateNext[0] = params.y;
+        stateNext[1] = params.yAddOne;
     },
 
     rhs(_imports, t, y, dydt) {
@@ -21,7 +21,7 @@ export const constantGrad: ContinuousGeneratorODE<ConstantGradShared, null, null
         return output;
     },
 
-    update(_imports, time: number, dt: number, state: number[], shared, internal: null, stateNext: number[]) {
+    update(_imports, time: number, dt: number, state: number[], params, internal: null, stateNext: number[]) {
         // tests end at time = 10
         if (time === 8) {
             stateNext[0] = 100;
@@ -40,8 +40,8 @@ export const constantGrad: ContinuousGeneratorODE<ConstantGradShared, null, null
         return new imports.Packer({ shape });
     },
 
-    updateShared(_imports, shared, newShared) {
-        shared.y = newShared.y;
-        shared.yAddOne = newShared.yAddOne;
+    updateParams(_imports, params, newParams) {
+        params.y = newParams.y;
+        params.yAddOne = newParams.yAddOne;
     }
 };

--- a/tests/examples/constantGradDelay.ts
+++ b/tests/examples/constantGradDelay.ts
@@ -1,6 +1,6 @@
 import type { ContinuousGeneratorDDE } from "../../src/interfaces/generators/ContinuousGenerator.ts";
 
-export interface ConstantGradDelayShared {
+export interface ConstantGradDelayParams {
     m: number;
     x: number;
     c: number;
@@ -8,13 +8,13 @@ export interface ConstantGradDelayShared {
     yDelay1: number;
 }
 
-export const constantGradDelay: ContinuousGeneratorDDE<ConstantGradDelayShared, null, null> = {
-    initial(_imports, time: number, shared, internal: null, stateNext: number[]) {
-        stateNext[0] = shared.m;
-        stateNext[1] = shared.x;
-        stateNext[2] = shared.c;
-        stateNext[3] = shared.y;
-        stateNext[4] = shared.yDelay1;
+export const constantGradDelay: ContinuousGeneratorDDE<ConstantGradDelayParams, null, null> = {
+    initial(_imports, time: number, params, internal: null, stateNext: number[]) {
+        stateNext[0] = params.m;
+        stateNext[1] = params.x;
+        stateNext[2] = params.c;
+        stateNext[3] = params.y;
+        stateNext[4] = params.yDelay1;
     },
 
     rhs(_imports, t, y, dydt) {
@@ -31,7 +31,7 @@ export const constantGradDelay: ContinuousGeneratorDDE<ConstantGradDelayShared, 
         return output;
     },
 
-    update(_imports, time: number, dt: number, state: number[], shared, internal: null, stateNext: number[]) {
+    update(_imports, time: number, dt: number, state: number[], params, internal: null, stateNext: number[]) {
         if (Math.abs(time - 8) < 1e-10) {
             stateNext[0] = 100;
         }
@@ -56,11 +56,11 @@ export const constantGradDelay: ContinuousGeneratorDDE<ConstantGradDelayShared, 
         return new imports.Packer({ shape });
     },
 
-    updateShared(_imports, shared, newShared) {
-        shared.m = newShared.m;
-        shared.x = newShared.x;
-        shared.c = newShared.c;
-        shared.y = newShared.y;
-        shared.yDelay1 = newShared.yDelay1;
+    updateParams(_imports, params, newParams) {
+        params.m = newParams.m;
+        params.x = newParams.x;
+        params.c = newParams.c;
+        params.y = newParams.y;
+        params.yDelay1 = newParams.yDelay1;
     }
 };

--- a/tests/examples/constantGradNoUpdate.ts
+++ b/tests/examples/constantGradNoUpdate.ts
@@ -1,14 +1,14 @@
 import type { ContinuousGeneratorODE } from "../../src/interfaces/generators/ContinuousGenerator.ts";
 
-export interface ConstantGradNoUpdateShared {
+export interface ConstantGradNoUpdateParams {
     y: number;
     yAddOne: number;
 }
 
-export const constantGradNoUpdate: ContinuousGeneratorODE<ConstantGradNoUpdateShared, null, null> = {
-    initial(_imports, time: number, shared, internal: null, stateNext: number[]) {
-        stateNext[0] = shared.y;
-        stateNext[1] = shared.yAddOne;
+export const constantGradNoUpdate: ContinuousGeneratorODE<ConstantGradNoUpdateParams, null, null> = {
+    initial(_imports, time: number, params, internal: null, stateNext: number[]) {
+        stateNext[0] = params.y;
+        stateNext[1] = params.yAddOne;
     },
 
     rhs(_imports, t, y, dydt) {
@@ -33,8 +33,8 @@ export const constantGradNoUpdate: ContinuousGeneratorODE<ConstantGradNoUpdateSh
         return new imports.Packer({ shape });
     },
 
-    updateShared(_imports, shared, newShared) {
-        shared.y = newShared.y;
-        shared.yAddOne = newShared.yAddOne;
+    updateParams(_imports, params, newParams) {
+        params.y = newParams.y;
+        params.yAddOne = newParams.yAddOne;
     }
 };

--- a/tests/examples/discreteSIR.ts
+++ b/tests/examples/discreteSIR.ts
@@ -1,7 +1,7 @@
 import type { Random } from "@reside-ic/random";
 import type { DiscreteGenerator } from "../../src/interfaces/generators/DiscreteGenerator.ts";
 
-export interface SIRShared {
+export interface SIRParams {
     N: number;
     I0: number;
     beta: number;
@@ -12,13 +12,13 @@ export interface SIRData {
     prevalence: number;
 }
 
-export const discreteSIR: DiscreteGenerator<SIRShared, null, SIRData> = {
+export const discreteSIR: DiscreteGenerator<SIRParams, null, SIRData> = {
     // it would be more js-ish if we returned an array, but that would
     // be harder once we work out how to get read-write slices from
     // ndarray.
-    initial(_imports, time: number, shared: SIRShared, internal: null, stateNext: number[]) {
-        stateNext[0] = shared.N - shared.I0;
-        stateNext[1] = shared.I0;
+    initial(_imports, time: number, params: SIRParams, internal: null, stateNext: number[]) {
+        stateNext[0] = params.N - params.I0;
+        stateNext[1] = params.I0;
         stateNext[2] = 0;
         stateNext[3] = 0;
         stateNext[4] = 0;
@@ -29,7 +29,7 @@ export const discreteSIR: DiscreteGenerator<SIRShared, null, SIRData> = {
         time: number,
         dt: number,
         state: number[],
-        shared: SIRShared,
+        params: SIRParams,
         internal: null,
         stateNext: number[],
         random: Random
@@ -39,8 +39,8 @@ export const discreteSIR: DiscreteGenerator<SIRShared, null, SIRData> = {
         const R = state[2];
         const cases_cumul = state[3];
         const cases_inc = state[4];
-        const p_SI = 1 - Math.exp(((-shared.beta * I) / shared.N) * dt);
-        const p_IR = 1 - Math.exp(-shared.gamma * dt);
+        const p_SI = 1 - Math.exp(((-params.beta * I) / params.N) * dt);
+        const p_IR = 1 - Math.exp(-params.gamma * dt);
         const n_SI = random.binomial(S, p_SI);
         const n_IR = random.binomial(I, p_IR);
         stateNext[0] = S - n_SI;
@@ -51,12 +51,12 @@ export const discreteSIR: DiscreteGenerator<SIRShared, null, SIRData> = {
     },
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    internal(_imports, shared: SIRShared): null {
+    internal(_imports, params: SIRParams): null {
         return null;
     },
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    packingState(imports, shared: SIRShared) {
+    packingState(imports, params: SIRParams) {
         const shape = new Map<string, number[]>([
             ["S", []],
             ["I", []],
@@ -72,7 +72,7 @@ export const discreteSIR: DiscreteGenerator<SIRShared, null, SIRData> = {
         time: number,
         state: number[],
         data: SIRData,
-        shared: SIRShared, // eslint-disable-line @typescript-eslint/no-unused-vars
+        params: SIRParams, // eslint-disable-line @typescript-eslint/no-unused-vars
         internal: null, // eslint-disable-line @typescript-eslint/no-unused-vars
         random: Random // eslint-disable-line @typescript-eslint/no-unused-vars
     ): number {
@@ -81,10 +81,10 @@ export const discreteSIR: DiscreteGenerator<SIRShared, null, SIRData> = {
         return imports.math.poissonLogDensity(observedPrevalence, modelledPrevalence);
     },
 
-    updateShared(_imports, shared: SIRShared, newShared: SIRShared) {
+    updateParams(_imports, params: SIRParams, newParams: SIRParams) {
         // does not update N
-        shared.I0 = newShared.I0;
-        shared.beta = newShared.beta;
-        shared.gamma = newShared.gamma;
+        params.I0 = newParams.I0;
+        params.beta = newParams.beta;
+        params.gamma = newParams.gamma;
     }
 };

--- a/tests/examples/discreteWalk.ts
+++ b/tests/examples/discreteWalk.ts
@@ -1,21 +1,21 @@
 import type { Random } from "@reside-ic/random";
 import type { DiscreteGenerator } from "../../src/interfaces/generators/DiscreteGenerator.ts";
 
-export interface WalkShared {
+export interface WalkParams {
     n: number;
     sd: number;
 }
 
-const checkStateRange = (state: number[], shared: WalkShared) => {
-    if (state.length < shared.n) {
-        throw RangeError(`State must have length of at least ${shared.n}`);
+const checkStateRange = (state: number[], params: WalkParams) => {
+    if (state.length < params.n) {
+        throw RangeError(`State must have length of at least ${params.n}`);
     }
 };
 
-export const discreteWalk: DiscreteGenerator<WalkShared, null, null> = {
-    initial(_imports, time: number, shared: WalkShared, internal: null, stateNext: number[]) {
-        checkStateRange(stateNext, shared);
-        for (let i = 0; i < shared.n; i++) {
+export const discreteWalk: DiscreteGenerator<WalkParams, null, null> = {
+    initial(_imports, time: number, params: WalkParams, internal: null, stateNext: number[]) {
+        checkStateRange(stateNext, params);
+        for (let i = 0; i < params.n; i++) {
             stateNext[i] = time;
         }
     },
@@ -25,30 +25,30 @@ export const discreteWalk: DiscreteGenerator<WalkShared, null, null> = {
         time: number,
         dt: number,
         state: number[],
-        shared: WalkShared,
+        params: WalkParams,
         internal: null,
         stateNext: number[],
         random: Random
     ) {
-        checkStateRange(state, shared);
-        checkStateRange(stateNext, shared);
-        for (let i = 0; i < shared.n; i++) {
-            stateNext[i] = random.normal(state[i], shared.sd);
+        checkStateRange(state, params);
+        checkStateRange(stateNext, params);
+        for (let i = 0; i < params.n; i++) {
+            stateNext[i] = random.normal(state[i], params.sd);
         }
     },
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    internal(_imports, shared: WalkShared): null {
+    internal(_imports, params: WalkParams): null {
         return null;
     },
 
-    packingState(imports, shared: WalkShared) {
-        const shape = new Map<string, number[]>([["values", [shared.n]]]);
+    packingState(imports, params: WalkParams) {
+        const shape = new Map<string, number[]>([["values", [params.n]]]);
         return new imports.Packer({ shape });
     },
 
-    updateShared(_imports, shared: WalkShared, newShared: WalkShared) {
-        shared.n = newShared.n;
-        shared.sd = newShared.sd;
+    updateParams(_imports, params: WalkParams, newParams: WalkParams) {
+        params.n = newParams.n;
+        params.sd = newParams.sd;
     }
 };

--- a/tests/examples/zeroTwice.ts
+++ b/tests/examples/zeroTwice.ts
@@ -6,12 +6,12 @@ export interface ABState {
 }
 
 export const zeroTwice: DiscreteGenerator<ABState, null, null> = {
-    initial(_imports, _time, _shared, _internal, stateNext) {
+    initial(_imports, _time, _params, _internal, stateNext) {
         stateNext[0] = 0;
         stateNext[1] = 0;
     },
 
-    update(_imports, _time, _dt, state, _shared, _internal, stateNext) {
+    update(_imports, _time, _dt, state, _params, _internal, stateNext) {
         stateNext[0] = state[0] + 1;
         stateNext[1] = state[1] + 1;
     },
@@ -24,10 +24,10 @@ export const zeroTwice: DiscreteGenerator<ABState, null, null> = {
         return new imports.Packer({ shape });
     },
 
-    getZeroEvery(_imports, shared) {
+    getZeroEvery(_imports, params) {
         return [
-            [shared.a, [0]],
-            [shared.b, [1]]
+            [params.a, [0]],
+            [params.b, [1]]
         ];
     },
 
@@ -35,5 +35,5 @@ export const zeroTwice: DiscreteGenerator<ABState, null, null> = {
         return null;
     },
 
-    updateShared() {}
+    updateParams() {}
 };

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -68,36 +68,14 @@ describe("checkIntegerInRange", () => {
 
 describe("ndArrayFrom", () => {
     test("can convert number[][] to ndArray", () => {
-        const result = ndArrayFrom([
-            [1, 2],
-            [3, 4],
-            [5, 6]
-        ]);
-        expect(result.shape).toStrictEqual([3, 2]);
-        expect(result.get(0, 0)).toBe(1);
-        expect(result.get(0, 1)).toBe(2);
-        expect(result.get(1, 0)).toBe(3);
-        expect(result.get(1, 1)).toBe(4);
-        expect(result.get(2, 0)).toBe(5);
-        expect(result.get(2, 1)).toBe(6);
+        const result = ndArrayFrom([1, 2]);
+        expect(result.shape).toStrictEqual([2]);
+        expect(result.get(0)).toBe(1);
+        expect(result.get(1)).toBe(2);
     });
 
     test("throws error if source length is 0", () => {
         expect(() => ndArrayFrom([])).toThrow("Cannot convert from empty source");
-    });
-
-    test("throws error if source arrays are different lengths", () => {
-        expect(() =>
-            ndArrayFrom([
-                [1, 2],
-                [3, 4, 5]
-            ])
-        ).toThrow("Source arrays must all be the same length");
-    });
-
-    test("can convert array of empty arrays", () => {
-        const result = ndArrayFrom([[], []]);
-        expect(result.shape).toStrictEqual([2, 0]);
     });
 });
 


### PR DESCRIPTION
Closes #27 

Looks big but mainly programmatic changes!

Main changes:
* removes groups
* changes `shared` to `params` everywhere
* simplifies System by not having a solver per group per particle, instead just one solver per system