### PR TITLE
Add array utility functions

### DIFF
--- a/src/interfaces/generators/Imports.ts
+++ b/src/interfaces/generators/Imports.ts
@@ -1,13 +1,11 @@
-import { poissonLogDensity } from "../../density.ts";
 import { Packer } from "../../Packer.ts";
-
-const math = {
-    poissonLogDensity
-};
+import { array } from "./imports/array.ts";
+import { math } from "./imports/math.ts";
 
 export const imports = {
     Packer,
-    math
+    math,
+    array
 };
 
 export type Imports = typeof imports;

--- a/src/interfaces/generators/imports/array.ts
+++ b/src/interfaces/generators/imports/array.ts
@@ -1,7 +1,8 @@
 type Op = (agg: number, x: number) => number;
 type Range = [number, number];
 
-// this file is based on dust2's implementation, for more details see: https://github.com/mrc-ide/dust2/blob/83721f78fda9b4124e1cda3ae24e3f2da82ca2d0/inst/include/dust2/array.hpp#L115
+// this file is based on dust2's implementation, for more details see:
+// https://github.com/mrc-ide/dust2/blob/83721f78fda9b4124e1cda3ae24e3f2da82ca2d0/inst/include/dust2/array.hpp#L115
 //
 // it calculates column major flat indicies from subranges along each dimension and applies
 // +, *, ... operations to those values

--- a/src/interfaces/generators/imports/array.ts
+++ b/src/interfaces/generators/imports/array.ts
@@ -1,0 +1,178 @@
+type Op = (agg: number, x: number) => number;
+type Range = [number, number];
+
+const reduceAll = (arr: number[], op: Op, init: number) => {
+    return arr.reduce(op, init);
+};
+
+const reduce1 = (arr: number[], _dim: DimUtils, i: Range, op: Op, init: number) => {
+    let ret = init;
+    for (let ii = i[0]; ii <= i[1]; ii++) {
+        ret = op(ret, arr[ii]);
+    }
+    return ret;
+};
+
+const reduce2 = (arr: number[], dim: DimUtils, i: Range, j: Range, op: Op, init: number) => {
+    let ret = init;
+    for (let jj = j[0]; jj <= j[1]; jj++) {
+        for (let ii = i[0]; ii <= i[1]; ii++) {
+            ret = op(ret, arr[ii + jj * dim.mult[1]]);
+        }
+    }
+    return ret;
+};
+
+const reduce3 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range, op: Op, init: number) => {
+    let ret = init;
+    for (let kk = k[0]; kk <= k[1]; kk++) {
+        for (let jj = j[0]; jj <= j[1]; jj++) {
+            for (let ii = i[0]; ii <= i[1]; ii++) {
+                ret = op(ret, arr[ii + jj * dim.mult[1] + kk * dim.mult[2]]);
+            }
+        }
+    }
+    return ret;
+};
+
+const reduce4 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range, l: Range, op: Op, init: number) => {
+    let ret = init;
+    for (let ll = l[0]; ll <= l[1]; ll++) {
+        for (let kk = k[0]; kk <= k[1]; kk++) {
+            for (let jj = j[0]; jj <= j[1]; jj++) {
+                for (let ii = i[0]; ii <= i[1]; ii++) {
+                    ret = op(ret, arr[ii + jj * dim.mult[1] + kk * dim.mult[2] + ll * dim.mult[3]]);
+                }
+            }
+        }
+    }
+    return ret;
+};
+
+const sumOp = (agg: number, x: number) => agg + x;
+const sumAll = (arr: number[]) => {
+    return reduceAll(arr, sumOp, 0);
+};
+const sum1 = (arr: number[], dim: DimUtils, i: Range) => {
+    return reduce1(arr, dim, i, sumOp, 0);
+};
+const sum2 = (arr: number[], dim: DimUtils, i: Range, j: Range) => {
+    return reduce2(arr, dim, i, j, sumOp, 0);
+};
+const sum3 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range) => {
+    return reduce3(arr, dim, i, j, k, sumOp, 0);
+};
+const sum4 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range, l: Range) => {
+    return reduce4(arr, dim, i, j, k, l, sumOp, 0);
+};
+
+const prodOp = (agg: number, x: number) => agg * x;
+const prodAll = (arr: number[]) => {
+    return reduceAll(arr, prodOp, 1);
+};
+const prod1 = (arr: number[], dim: DimUtils, i: Range) => {
+    return reduce1(arr, dim, i, prodOp, 1);
+};
+const prod2 = (arr: number[], dim: DimUtils, i: Range, j: Range) => {
+    return reduce2(arr, dim, i, j, prodOp, 1);
+};
+const prod3 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range) => {
+    return reduce3(arr, dim, i, j, k, prodOp, 1);
+};
+const prod4 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range, l: Range) => {
+    return reduce4(arr, dim, i, j, k, l, prodOp, 1);
+};
+
+const minOp = (agg: number, x: number) => Math.min(agg, x);
+const minAll = (arr: number[]) => {
+    return reduceAll(arr, minOp, Infinity);
+};
+const min1 = (arr: number[], dim: DimUtils, i: Range) => {
+    return reduce1(arr, dim, i, minOp, Infinity);
+};
+const min2 = (arr: number[], dim: DimUtils, i: Range, j: Range) => {
+    return reduce2(arr, dim, i, j, minOp, Infinity);
+};
+const min3 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range) => {
+    return reduce3(arr, dim, i, j, k, minOp, Infinity);
+};
+const min4 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range, l: Range) => {
+    return reduce4(arr, dim, i, j, k, l, minOp, Infinity);
+};
+
+const maxOp = (agg: number, x: number) => Math.max(agg, x);
+const maxAll = (arr: number[]) => {
+    return reduceAll(arr, maxOp, -Infinity);
+};
+const max1 = (arr: number[], dim: DimUtils, i: Range) => {
+    return reduce1(arr, dim, i, maxOp, -Infinity);
+};
+const max2 = (arr: number[], dim: DimUtils, i: Range, j: Range) => {
+    return reduce2(arr, dim, i, j, maxOp, -Infinity);
+};
+const max3 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range) => {
+    return reduce3(arr, dim, i, j, k, maxOp, -Infinity);
+};
+const max4 = (arr: number[], dim: DimUtils, i: Range, j: Range, k: Range, l: Range) => {
+    return reduce4(arr, dim, i, j, k, l, maxOp, -Infinity);
+};
+
+const assignArrayToSliceOfArray = (bigArr: number[], startOffset: number, smallArr: number[]) => {
+    for (let i = startOffset; i < startOffset + smallArr.length; i++) {
+        bigArr[i] = smallArr[i - startOffset];
+    }
+};
+
+// useful utility for getting/calculating dim information,
+// mult is partial product of all dimensions up to that dimension
+export type DimUtils = {
+    dim: number[];
+    size: number;
+    mult: number[];
+};
+
+const getDimObj = () => {
+    const dim: Record<string, DimUtils> = {};
+    return new Proxy(dim, {
+        set(target, p: string, newValue: number[]) {
+            if (newValue.length === 0) {
+                target[p] = { dim: [], size: 1, mult: [] };
+                return true;
+            }
+
+            const prod = [1];
+            for (let i = 0; i < newValue.length; i++) {
+                const d = newValue[i];
+                prod.push(prod[i] * d);
+            }
+            const size = prod.at(-1)!;
+            target[p] = { dim: newValue, size, mult: prod.slice(0, -1) };
+            return true;
+        }
+    });
+};
+
+export const array = {
+    sumAll,
+    sum1,
+    sum2,
+    sum3,
+    sum4,
+    prodAll,
+    prod1,
+    prod2,
+    prod3,
+    prod4,
+    minAll,
+    min1,
+    min2,
+    min3,
+    min4,
+    maxAll,
+    max1,
+    max2,
+    max3,
+    max4,
+    assignArrayToSliceOfArray,
+    getDimObj
+};

--- a/src/interfaces/generators/imports/array.ts
+++ b/src/interfaces/generators/imports/array.ts
@@ -1,6 +1,11 @@
 type Op = (agg: number, x: number) => number;
 type Range = [number, number];
 
+// this file is based on dust2's implementation, for more details see: https://github.com/mrc-ide/dust2/blob/83721f78fda9b4124e1cda3ae24e3f2da82ca2d0/inst/include/dust2/array.hpp#L115
+//
+// it calculates column major flat indicies from subranges along each dimension and applies
+// +, *, ... operations to those values
+
 const reduceAll = (arr: number[], op: Op, init: number) => {
     return arr.reduce(op, init);
 };
@@ -131,6 +136,21 @@ export type DimUtils = {
     mult: number[];
 };
 
+/*
+  Example usage
+  =============
+
+  const dim = getDimObj();
+
+  dim.x = [2, 3, 5]; // setter triggers and will calculate dim, size and mult
+  
+  console.log(dim.x)
+  -> {
+    dim: [2, 3, 5], // same as input
+    size: 30, // 2 * 3 * 5, total size of flat array
+    mult: [1, 2, 6] // stride length, cumulative prod of dim starting at 1
+  }
+*/
 const getDimObj = () => {
     const dim: Record<string, DimUtils> = {};
     return new Proxy(dim, {

--- a/src/interfaces/generators/imports/math.ts
+++ b/src/interfaces/generators/imports/math.ts
@@ -1,0 +1,5 @@
+import { poissonLogDensity } from "../../../density";
+
+export const math = {
+    poissonLogDensity
+};

--- a/tests/importsArray.test.ts
+++ b/tests/importsArray.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+import { array, DimUtils } from "../src/interfaces/generators/imports/array";
+
+describe("array", () => {
+    // 5 x 4 x 3 x 2 in the 4D case, otherwise dimensions up to the dim index
+    // so in 3D it will be 5 x 4 x 6 for this test, and in 2D it will be
+    // 5 x 24
+    const totalSize = 5 * 4 * 3 * 2;
+    const dim4d: DimUtils = {
+        dim: [5, 4, 3, 2],
+        size: totalSize,
+        mult: [1, 5, 20, 60]
+    };
+    const dim3d: DimUtils = {
+        dim: [5, 4, 6],
+        size: totalSize,
+        mult: [1, 5, 20]
+    };
+    const dim2d: DimUtils = {
+        dim: [5, 24],
+        size: totalSize,
+        mult: [1, 5]
+    };
+    const dim1d: DimUtils = {
+        dim: [120],
+        size: totalSize,
+        mult: [1]
+    };
+
+    test("sum functions work as expected", () => {
+        const arr = Array.from({ length: totalSize }).map(() => 1);
+        expect(array.sumAll(arr)).toBe(totalSize);
+        expect(
+            // sum over
+            // i = 2, 3;
+            // j = 1, 2, 3;
+            // k = 0, 1;
+            // l = 1;
+            array.sum4(arr, dim4d, [2, 3], [1, 3], [0, 1], [1, 1])
+        ).toBe(2 * 3 * 2 * 1); // lengths of i,j,k,l intervals
+        expect(array.sum3(arr, dim3d, [2, 3], [1, 3], [2, 5])).toBe(2 * 3 * 4);
+        expect(array.sum2(arr, dim2d, [2, 3], [11, 20])).toBe(2 * 10);
+        expect(array.sum1(arr, dim1d, [2, 100])).toBe(99);
+    });
+
+    test("prod functions work as expected", () => {
+        const arr = Array.from({ length: totalSize }).map(() => 0.9);
+        expect(array.prodAll(arr)).toBeCloseTo(Math.pow(0.9, totalSize));
+        expect(array.prod4(arr, dim4d, [2, 3], [1, 3], [0, 1], [1, 1])).toBeCloseTo(Math.pow(0.9, 2 * 3 * 2 * 1));
+        expect(array.prod3(arr, dim3d, [2, 3], [1, 3], [2, 5])).toBeCloseTo(Math.pow(0.9, 2 * 3 * 4));
+        expect(array.prod2(arr, dim2d, [2, 3], [11, 20])).toBeCloseTo(Math.pow(0.9, 2 * 10));
+        expect(array.prod1(arr, dim1d, [2, 100])).toBeCloseTo(Math.pow(0.9, 99));
+    });
+
+    test("min functions work as expected", () => {
+        const arr = Array.from({ length: totalSize }).map((_, i) => totalSize - i);
+        expect(array.minAll(arr)).toBe(1);
+        expect(
+            // this array is decreasing so the min will effectively be located at the
+            // maximum index it can get to, which is just the flat index of the maximum
+            // of the coordinate ranges
+            array.min4(arr, dim4d, [2, 3], [1, 3], [0, 1], [1, 1])
+        ).toBe(totalSize - (3 + 3 * dim4d.mult[1] + 1 * dim4d.mult[2] + 1 * dim4d.mult[3]));
+        expect(array.min3(arr, dim3d, [2, 3], [1, 3], [2, 5])).toBe(
+            totalSize - (3 + 3 * dim4d.mult[1] + 5 * dim4d.mult[2])
+        );
+        expect(array.min2(arr, dim2d, [2, 3], [11, 20])).toBe(totalSize - (3 + 20 * dim4d.mult[1]));
+        expect(array.min1(arr, dim1d, [2, 100])).toBe(totalSize - 100);
+    });
+
+    test("max functions work as expected", () => {
+        // using property that max(-arr) = -min(arr)
+        const arr = Array.from({ length: totalSize }).map((_, i) => i - totalSize);
+        expect(array.maxAll(arr)).toBe(-1);
+        expect(array.max4(arr, dim4d, [2, 3], [1, 3], [0, 1], [1, 1])).toBe(
+            3 + 3 * dim4d.mult[1] + 1 * dim4d.mult[2] + 1 * dim4d.mult[3] - totalSize
+        );
+        expect(array.max3(arr, dim3d, [2, 3], [1, 3], [2, 5])).toBe(
+            3 + 3 * dim4d.mult[1] + 5 * dim4d.mult[2] - totalSize
+        );
+        expect(array.max2(arr, dim2d, [2, 3], [11, 20])).toBe(3 + 20 * dim4d.mult[1] - totalSize);
+        expect(array.max1(arr, dim1d, [2, 100])).toBe(100 - totalSize);
+    });
+
+    test("assign array slice function works", () => {
+        const bigArr = [1, 2, 3, 4, 5];
+        const smallArr = [10, 20, 30];
+        array.assignArrayToSliceOfArray(bigArr, 1, smallArr);
+        expect(bigArr).toStrictEqual([1, 10, 20, 30, 5]);
+    });
+
+    test("dim object proxy works as expected", () => {
+        const dimObj = array.getDimObj();
+        // @ts-expect-error typescript doesn't seem to respect
+        // proxies
+        dimObj.x = [5, 4, 3, 2];
+        expect(dimObj.x).toStrictEqual(dim4d);
+    });
+});

--- a/tests/importsArray.test.ts
+++ b/tests/importsArray.test.ts
@@ -96,4 +96,12 @@ describe("array", () => {
         dimObj.x = [5, 4, 3, 2];
         expect(dimObj.x).toStrictEqual(dim4d);
     });
+
+    test("dim object proxy works as expected for scalar dim", () => {
+        const dimObj = array.getDimObj();
+        // @ts-expect-error typescript doesn't seem to respect
+        // proxies
+        dimObj.x = [];
+        expect(dimObj.x).toStrictEqual({ dim: [], size: 1, mult: [] });
+    });
 });


### PR DESCRIPTION
Closes #30 

these functions are in dust2 in pretty much the same form (the sum, prod, min and max ones), they let you reduce along any slice of any dimension and are needed for array support

the assign array slice function lets us assign to part of the slice of the flat array easily (it is used for outputs in odin2)

the dim object is a nice utility that lets us do some processing as we assign to a property of the object (which keeps it simpler for odin2 code generation as this is what the c++ code does as well)