### PR TITLE
Add interpolate utilities

### DIFF
--- a/src/interfaces/generators/Imports.ts
+++ b/src/interfaces/generators/Imports.ts
@@ -1,13 +1,15 @@
 import { Packer } from "../../Packer.ts";
 import { array } from "./imports/array.ts";
 import { interpolate } from "./imports/interpolate.ts";
+import { io } from "./imports/io.ts";
 import { math } from "./imports/math.ts";
 
 export const imports = {
     Packer,
     math,
     array,
-    interpolate
+    interpolate,
+    io
 };
 
 export type Imports = typeof imports;

--- a/src/interfaces/generators/Imports.ts
+++ b/src/interfaces/generators/Imports.ts
@@ -1,11 +1,13 @@
 import { Packer } from "../../Packer.ts";
 import { array } from "./imports/array.ts";
+import { interpolate } from "./imports/interpolate.ts";
 import { math } from "./imports/math.ts";
 
 export const imports = {
     Packer,
     math,
-    array
+    array,
+    interpolate,
 };
 
 export type Imports = typeof imports;

--- a/src/interfaces/generators/Imports.ts
+++ b/src/interfaces/generators/Imports.ts
@@ -7,7 +7,7 @@ export const imports = {
     Packer,
     math,
     array,
-    interpolate,
+    interpolate
 };
 
 export type Imports = typeof imports;

--- a/src/interfaces/generators/imports/interpolate.ts
+++ b/src/interfaces/generators/imports/interpolate.ts
@@ -1,0 +1,83 @@
+import { DimUtils } from "./array";
+
+const interpolateSearch = (targetTime: number, times: number[], allowExtrapolateRhs: boolean) => {
+  if (targetTime < times[0]) {
+    throw new Error(
+      `Tried to interpolate at time t = ${targetTime}, which is before first time (${times[0]})`
+    );
+  }
+
+  const n = times.length;
+
+  const upperTimeIdx = times.findIndex(t => targetTime <= t);
+  if (upperTimeIdx === -1) {
+    // target time greater than all times
+    if (allowExtrapolateRhs) {
+      return n - 1;
+    } else {
+      throw new Error(
+        `Tried to interpolate at time t = ${targetTime}, which is after last time (${times[n - 1]})`
+      )
+    }
+  }
+
+  return times[upperTimeIdx] !== targetTime ? upperTimeIdx - 1 : upperTimeIdx;
+}
+
+const validateTime = (times: number[], lengthY: number, nameT: string, nameY: string) => {
+  if (times.length !== lengthY) {
+    throw new Error(
+      `Time variable '${nameT}' and interpolation target '${nameY}' must have the same length, `
+      + `but do not (${times.length} vs ${lengthY})`
+    );
+  }
+
+  for (let i = 1; i < times.length; i++) {
+    if (times[i - 1] >= times[i]) {
+      throw new Error(
+        `Time variable '${nameT}' must be strictly increasing but was not at index ${i}`
+      );
+    }
+  }
+};
+
+class InterpolateConstant {
+  constructor(
+    public times: number[],
+    public y: number[],
+    nameT: string,
+    nameY: string,
+  ) {
+    validateTime(times, y.length, nameT, nameY);
+  };
+
+  eval = (t: number) => {
+    const idx = interpolateSearch(t, this.times, true);
+    return this.y[idx];
+  };
+}
+
+class InterpolateConstantArray {
+  constructor(
+    public times: number[],
+    public y: number[],
+    public dimTarget: DimUtils,
+    nameT: string,
+    nameY: string,
+  ) {
+    const lengthY = y.length / dimTarget.size;
+    validateTime(times, lengthY, nameT, nameY);
+  };
+
+  eval = (t: number) => {
+    const idx = interpolateSearch(t, this.times, true);
+    const size = this.dimTarget.size;
+    const startOffset = size * idx;
+    return this.y.slice(startOffset, startOffset + size);
+  };
+}
+
+export const interpolate = {
+  InterpolateConstant,
+  InterpolateConstantArray,
+};

--- a/src/interfaces/generators/imports/interpolate.ts
+++ b/src/interfaces/generators/imports/interpolate.ts
@@ -1,5 +1,6 @@
 import { DimUtils } from "./array";
 
+// this function finds the time index in the times array that is just before the targetTime
 const interpolateSearch = (targetTime: number, times: number[], allowExtrapolateRhs: boolean) => {
     if (targetTime < times[0]) {
         throw new Error(`Tried to interpolate at time t = ${targetTime}, which is before first time (${times[0]})`);

--- a/src/interfaces/generators/imports/interpolate.ts
+++ b/src/interfaces/generators/imports/interpolate.ts
@@ -1,83 +1,79 @@
 import { DimUtils } from "./array";
 
 const interpolateSearch = (targetTime: number, times: number[], allowExtrapolateRhs: boolean) => {
-  if (targetTime < times[0]) {
-    throw new Error(
-      `Tried to interpolate at time t = ${targetTime}, which is before first time (${times[0]})`
-    );
-  }
-
-  const n = times.length;
-
-  const upperTimeIdx = times.findIndex(t => targetTime <= t);
-  if (upperTimeIdx === -1) {
-    // target time greater than all times
-    if (allowExtrapolateRhs) {
-      return n - 1;
-    } else {
-      throw new Error(
-        `Tried to interpolate at time t = ${targetTime}, which is after last time (${times[n - 1]})`
-      )
+    if (targetTime < times[0]) {
+        throw new Error(`Tried to interpolate at time t = ${targetTime}, which is before first time (${times[0]})`);
     }
-  }
 
-  return times[upperTimeIdx] !== targetTime ? upperTimeIdx - 1 : upperTimeIdx;
-}
+    const n = times.length;
+
+    const upperTimeIdx = times.findIndex((t) => targetTime <= t);
+    if (upperTimeIdx === -1) {
+        // target time greater than all times
+        if (allowExtrapolateRhs) {
+            return n - 1;
+        } else {
+            throw new Error(
+                `Tried to interpolate at time t = ${targetTime}, which is after last time (${times[n - 1]})`
+            );
+        }
+    }
+
+    return times[upperTimeIdx] !== targetTime ? upperTimeIdx - 1 : upperTimeIdx;
+};
 
 const validateTime = (times: number[], lengthY: number, nameT: string, nameY: string) => {
-  if (times.length !== lengthY) {
-    throw new Error(
-      `Time variable '${nameT}' and interpolation target '${nameY}' must have the same length, `
-      + `but do not (${times.length} vs ${lengthY})`
-    );
-  }
-
-  for (let i = 1; i < times.length; i++) {
-    if (times[i - 1] >= times[i]) {
-      throw new Error(
-        `Time variable '${nameT}' must be strictly increasing but was not at index ${i}`
-      );
+    if (times.length !== lengthY) {
+        throw new Error(
+            `Time variable '${nameT}' and interpolation target '${nameY}' must have the same length, ` +
+                `but do not (${times.length} vs ${lengthY})`
+        );
     }
-  }
+
+    for (let i = 1; i < times.length; i++) {
+        if (times[i - 1] >= times[i]) {
+            throw new Error(`Time variable '${nameT}' must be strictly increasing but was not at index ${i}`);
+        }
+    }
 };
 
 class InterpolateConstant {
-  constructor(
-    public times: number[],
-    public y: number[],
-    nameT: string,
-    nameY: string,
-  ) {
-    validateTime(times, y.length, nameT, nameY);
-  };
+    constructor(
+        public times: number[],
+        public y: number[],
+        nameT: string,
+        nameY: string
+    ) {
+        validateTime(times, y.length, nameT, nameY);
+    }
 
-  eval = (t: number) => {
-    const idx = interpolateSearch(t, this.times, true);
-    return this.y[idx];
-  };
+    eval = (t: number) => {
+        const idx = interpolateSearch(t, this.times, true);
+        return this.y[idx];
+    };
 }
 
 class InterpolateConstantArray {
-  constructor(
-    public times: number[],
-    public y: number[],
-    public dimTarget: DimUtils,
-    nameT: string,
-    nameY: string,
-  ) {
-    const lengthY = y.length / dimTarget.size;
-    validateTime(times, lengthY, nameT, nameY);
-  };
+    constructor(
+        public times: number[],
+        public y: number[],
+        public dimTarget: DimUtils,
+        nameT: string,
+        nameY: string
+    ) {
+        const lengthY = y.length / dimTarget.size;
+        validateTime(times, lengthY, nameT, nameY);
+    }
 
-  eval = (t: number) => {
-    const idx = interpolateSearch(t, this.times, true);
-    const size = this.dimTarget.size;
-    const startOffset = size * idx;
-    return this.y.slice(startOffset, startOffset + size);
-  };
+    eval = (t: number) => {
+        const idx = interpolateSearch(t, this.times, true);
+        const size = this.dimTarget.size;
+        const startOffset = size * idx;
+        return this.y.slice(startOffset, startOffset + size);
+    };
 }
 
 export const interpolate = {
-  InterpolateConstant,
-  InterpolateConstantArray,
+    InterpolateConstant,
+    InterpolateConstantArray
 };

--- a/tests/importsInterpolate.test.ts
+++ b/tests/importsInterpolate.test.ts
@@ -3,117 +3,100 @@ import { interpolate } from "../src/interfaces/generators/imports/interpolate";
 import { DimUtils } from "../src/interfaces/generators/imports/array";
 
 describe("interpolate", () => {
-  const nameT = "t";
-  const nameY = "y";
+    const nameT = "t";
+    const nameY = "y";
 
-  test("interpolate constant throws error if times and y are different lengths", () => {
-    const times = [1];
-    const y = [1, 2];
-    expect(() => {
-      new interpolate.InterpolateConstant(times, y, nameT, nameY);
-    }).toThrow(
-      `Time variable '${nameT}' and interpolation target '${nameY}' `
-      + "must have the same length, but do not (1 vs 2)"
-    );
-  });
+    test("interpolate constant throws error if times and y are different lengths", () => {
+        const times = [1];
+        const y = [1, 2];
+        expect(() => {
+            new interpolate.InterpolateConstant(times, y, nameT, nameY);
+        }).toThrow(
+            `Time variable '${nameT}' and interpolation target '${nameY}' ` +
+                "must have the same length, but do not (1 vs 2)"
+        );
+    });
 
-  test("interpolate constant throws error if times is non increasing", () => {
-    const times = [1, 2, 1];
-    const y = [1, 2, 3];
-    expect(() => {
-      new interpolate.InterpolateConstant(times, y, nameT, nameY);
-    }).toThrow(
-      `Time variable '${nameT}' must be strictly increasing but was `
-      + "not at index 2"
-    );
-  });
+    test("interpolate constant throws error if times is non increasing", () => {
+        const times = [1, 2, 1];
+        const y = [1, 2, 3];
+        expect(() => {
+            new interpolate.InterpolateConstant(times, y, nameT, nameY);
+        }).toThrow(`Time variable '${nameT}' must be strictly increasing but was ` + "not at index 2");
+    });
 
-  test("interpolate constant eval works as expected", () => {
-    const times = [1, 10, 50, 100];
-    const y = [-1, -2, -3, -4];
-    const i = new interpolate.InterpolateConstant(times, y, nameT, nameY);
-    
-    expect(() => {
-      i.eval(0)
-    }).toThrow(
-      "Tried to interpolate at time t = 0, which is before "
-      + "first time (1)"
-    );
+    test("interpolate constant eval works as expected", () => {
+        const times = [1, 10, 50, 100];
+        const y = [-1, -2, -3, -4];
+        const i = new interpolate.InterpolateConstant(times, y, nameT, nameY);
 
-    expect(i.eval(1)).toBe(y[0]);
-    expect(i.eval(1.1)).toBe(y[0]);
-    expect(i.eval(9.9)).toBe(y[0]);
-    expect(i.eval(10)).toBe(y[1]);
-    expect(i.eval(49.99)).toBe(y[1]);
-    expect(i.eval(50)).toBe(y[2]);
-    expect(i.eval(50.01)).toBe(y[2]);
-    expect(i.eval(99.999)).toBe(y[2]);
-    expect(i.eval(100)).toBe(y[3]);
-    expect(i.eval(100.001)).toBe(y[3]);
-    expect(i.eval(100_000)).toBe(y[3]);
-  });
+        expect(() => {
+            i.eval(0);
+        }).toThrow("Tried to interpolate at time t = 0, which is before " + "first time (1)");
 
-  const dimUtils: DimUtils = { dim: [2, 3], size: 6, mult: [1, 2] };
+        expect(i.eval(1)).toBe(y[0]);
+        expect(i.eval(1.1)).toBe(y[0]);
+        expect(i.eval(9.9)).toBe(y[0]);
+        expect(i.eval(10)).toBe(y[1]);
+        expect(i.eval(49.99)).toBe(y[1]);
+        expect(i.eval(50)).toBe(y[2]);
+        expect(i.eval(50.01)).toBe(y[2]);
+        expect(i.eval(99.999)).toBe(y[2]);
+        expect(i.eval(100)).toBe(y[3]);
+        expect(i.eval(100.001)).toBe(y[3]);
+        expect(i.eval(100_000)).toBe(y[3]);
+    });
 
-  test("interpolate constant array throws error if times and y are different lengths", () => {
-    const times = [1, 2];
-    // dimUtils says this is 2 x 3, so this only have info for 1 time point
-    const y = [
-      1, 2, 3,
-      4, 5, 6,
-    ];
-    expect(() => {
-      new interpolate.InterpolateConstantArray(times, y, dimUtils, nameT, nameY);
-    }).toThrow(
-      `Time variable '${nameT}' and interpolation target '${nameY}' `
-      + "must have the same length, but do not (2 vs 1)"
-    );
-  });
+    const dimUtils: DimUtils = { dim: [2, 3], size: 6, mult: [1, 2] };
 
-  test("interpolate constant array throws error if times is non increasing", () => {
-    const times = [1, 0];
-    // 2 time points
-    const y = [
-      1, 2, 3,
-      4, 5, 6,
+    test("interpolate constant array throws error if times and y are different lengths", () => {
+        const times = [1, 2];
+        // dimUtils says this is 2 x 3, so this only have info for 1 time point
+        const y = [1, 2, 3, 4, 5, 6];
+        expect(() => {
+            new interpolate.InterpolateConstantArray(times, y, dimUtils, nameT, nameY);
+        }).toThrow(
+            `Time variable '${nameT}' and interpolation target '${nameY}' ` +
+                "must have the same length, but do not (2 vs 1)"
+        );
+    });
 
-      1, 2, 3,
-      4, 5, 6,
-    ];
-    expect(() => {
-      new interpolate.InterpolateConstantArray(times, y, dimUtils, nameT, nameY);
-    }).toThrow(
-      `Time variable '${nameT}' must be strictly increasing but was `
-      + "not at index 1"
-    );
-  });
+    test("interpolate constant array throws error if times is non increasing", () => {
+        const times = [1, 0];
+        // 2 time points
+        const y = [
+            1, 2, 3, 4, 5, 6,
 
-  test("interpolate constant array eval works as expected", () => {
-    const times = [1, 10, 50, 100];
-    const y0 = [-1, -1, -1, -1, -1, -1];
-    const y1 = [-2, -2, -2, -2, -2, -2];
-    const y2 = [-3, -3, -3, -3, -3, -3];
-    const y3 = [-4, -4, -4, -4, -4, -4];
-    const y = [...y0, ...y1, ...y2, ...y3];
-    const i = new interpolate.InterpolateConstantArray(times, y, dimUtils, nameT, nameY);
-    
-    expect(() => {
-      i.eval(0)
-    }).toThrow(
-      "Tried to interpolate at time t = 0, which is before "
-      + "first time (1)"
-    );
+            1, 2, 3, 4, 5, 6
+        ];
+        expect(() => {
+            new interpolate.InterpolateConstantArray(times, y, dimUtils, nameT, nameY);
+        }).toThrow(`Time variable '${nameT}' must be strictly increasing but was ` + "not at index 1");
+    });
 
-    expect(i.eval(1)).toStrictEqual(y0);
-    expect(i.eval(1.1)).toStrictEqual(y0);
-    expect(i.eval(9.9)).toStrictEqual(y0);
-    expect(i.eval(10)).toStrictEqual(y1);
-    expect(i.eval(49.99)).toStrictEqual(y1);
-    expect(i.eval(50)).toStrictEqual(y2);
-    expect(i.eval(50.01)).toStrictEqual(y2);
-    expect(i.eval(99.999)).toStrictEqual(y2);
-    expect(i.eval(100)).toStrictEqual(y3);
-    expect(i.eval(100.001)).toStrictEqual(y3);
-    expect(i.eval(100_000)).toStrictEqual(y3);
-  });
+    test("interpolate constant array eval works as expected", () => {
+        const times = [1, 10, 50, 100];
+        const y0 = [-1, -1, -1, -1, -1, -1];
+        const y1 = [-2, -2, -2, -2, -2, -2];
+        const y2 = [-3, -3, -3, -3, -3, -3];
+        const y3 = [-4, -4, -4, -4, -4, -4];
+        const y = [...y0, ...y1, ...y2, ...y3];
+        const i = new interpolate.InterpolateConstantArray(times, y, dimUtils, nameT, nameY);
+
+        expect(() => {
+            i.eval(0);
+        }).toThrow("Tried to interpolate at time t = 0, which is before " + "first time (1)");
+
+        expect(i.eval(1)).toStrictEqual(y0);
+        expect(i.eval(1.1)).toStrictEqual(y0);
+        expect(i.eval(9.9)).toStrictEqual(y0);
+        expect(i.eval(10)).toStrictEqual(y1);
+        expect(i.eval(49.99)).toStrictEqual(y1);
+        expect(i.eval(50)).toStrictEqual(y2);
+        expect(i.eval(50.01)).toStrictEqual(y2);
+        expect(i.eval(99.999)).toStrictEqual(y2);
+        expect(i.eval(100)).toStrictEqual(y3);
+        expect(i.eval(100.001)).toStrictEqual(y3);
+        expect(i.eval(100_000)).toStrictEqual(y3);
+    });
 });

--- a/tests/importsInterpolate.test.ts
+++ b/tests/importsInterpolate.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+import { interpolate } from "../src/interfaces/generators/imports/interpolate";
+import { DimUtils } from "../src/interfaces/generators/imports/array";
+
+describe("interpolate", () => {
+  const nameT = "t";
+  const nameY = "y";
+
+  test("interpolate constant throws error if times and y are different lengths", () => {
+    const times = [1];
+    const y = [1, 2];
+    expect(() => {
+      new interpolate.InterpolateConstant(times, y, nameT, nameY);
+    }).toThrow(
+      `Time variable '${nameT}' and interpolation target '${nameY}' `
+      + "must have the same length, but do not (1 vs 2)"
+    );
+  });
+
+  test("interpolate constant throws error if times is non increasing", () => {
+    const times = [1, 2, 1];
+    const y = [1, 2, 3];
+    expect(() => {
+      new interpolate.InterpolateConstant(times, y, nameT, nameY);
+    }).toThrow(
+      `Time variable '${nameT}' must be strictly increasing but was `
+      + "not at index 2"
+    );
+  });
+
+  test("interpolate constant eval works as expected", () => {
+    const times = [1, 10, 50, 100];
+    const y = [-1, -2, -3, -4];
+    const i = new interpolate.InterpolateConstant(times, y, nameT, nameY);
+    
+    expect(() => {
+      i.eval(0)
+    }).toThrow(
+      "Tried to interpolate at time t = 0, which is before "
+      + "first time (1)"
+    );
+
+    expect(i.eval(1)).toBe(y[0]);
+    expect(i.eval(1.1)).toBe(y[0]);
+    expect(i.eval(9.9)).toBe(y[0]);
+    expect(i.eval(10)).toBe(y[1]);
+    expect(i.eval(49.99)).toBe(y[1]);
+    expect(i.eval(50)).toBe(y[2]);
+    expect(i.eval(50.01)).toBe(y[2]);
+    expect(i.eval(99.999)).toBe(y[2]);
+    expect(i.eval(100)).toBe(y[3]);
+    expect(i.eval(100.001)).toBe(y[3]);
+    expect(i.eval(100_000)).toBe(y[3]);
+  });
+
+  const dimUtils: DimUtils = { dim: [2, 3], size: 6, mult: [1, 2] };
+
+  test("interpolate constant array throws error if times and y are different lengths", () => {
+    const times = [1, 2];
+    // dimUtils says this is 2 x 3, so this only have info for 1 time point
+    const y = [
+      1, 2, 3,
+      4, 5, 6,
+    ];
+    expect(() => {
+      new interpolate.InterpolateConstantArray(times, y, dimUtils, nameT, nameY);
+    }).toThrow(
+      `Time variable '${nameT}' and interpolation target '${nameY}' `
+      + "must have the same length, but do not (2 vs 1)"
+    );
+  });
+
+  test("interpolate constant array throws error if times is non increasing", () => {
+    const times = [1, 0];
+    // 2 time points
+    const y = [
+      1, 2, 3,
+      4, 5, 6,
+
+      1, 2, 3,
+      4, 5, 6,
+    ];
+    expect(() => {
+      new interpolate.InterpolateConstantArray(times, y, dimUtils, nameT, nameY);
+    }).toThrow(
+      `Time variable '${nameT}' must be strictly increasing but was `
+      + "not at index 1"
+    );
+  });
+
+  test("interpolate constant array eval works as expected", () => {
+    const times = [1, 10, 50, 100];
+    const y0 = [-1, -1, -1, -1, -1, -1];
+    const y1 = [-2, -2, -2, -2, -2, -2];
+    const y2 = [-3, -3, -3, -3, -3, -3];
+    const y3 = [-4, -4, -4, -4, -4, -4];
+    const y = [...y0, ...y1, ...y2, ...y3];
+    const i = new interpolate.InterpolateConstantArray(times, y, dimUtils, nameT, nameY);
+    
+    expect(() => {
+      i.eval(0)
+    }).toThrow(
+      "Tried to interpolate at time t = 0, which is before "
+      + "first time (1)"
+    );
+
+    expect(i.eval(1)).toStrictEqual(y0);
+    expect(i.eval(1.1)).toStrictEqual(y0);
+    expect(i.eval(9.9)).toStrictEqual(y0);
+    expect(i.eval(10)).toStrictEqual(y1);
+    expect(i.eval(49.99)).toStrictEqual(y1);
+    expect(i.eval(50)).toStrictEqual(y2);
+    expect(i.eval(50.01)).toStrictEqual(y2);
+    expect(i.eval(99.999)).toStrictEqual(y2);
+    expect(i.eval(100)).toStrictEqual(y3);
+    expect(i.eval(100.001)).toStrictEqual(y3);
+    expect(i.eval(100_000)).toStrictEqual(y3);
+  });
+});


### PR DESCRIPTION
Closes #31 

This adds interpolate utilities used by the code generation, currently we only have support for constant interpolation, this is the same in the code generation too, there is an arg called `allowExtrapolateRhs` which is currently only set to `true` but it will be set to `false` in another type of interpolation so ive left that in.

(also adding in io in imports file which i forgot to do last pr)